### PR TITLE
Transact

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 ### Changes
 
+- SQLite: added `.runOnceOnOpen()` to register functions that should be run on the open database but shouldn't open the database
 - Renamed `dispatch()` to `addEvent()` inside the event processing flow. `dispatch()` still works but gives a deprecation warning. The `.dispatch()` method is not affected.
 
 ### Deprecations

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Changes
+
+- Renamed `dispatch()` to `addEvent()` inside the event processing flow. `dispatch()` still works but gives a deprecation warning. The `.dispatch()` method is not affected.
+
+### Deprecations
+
+- The `dispatch()` function that is passed to redux methods was renamed to `addEvent()`.
+
 ### Breaking
 
 - JsonModel: `.get()` now uses the column's `where` and `whereVal` like `.search()` does. This means that it will return different results than in v3, but those cases were likely to be unintended.

--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,7 @@
 ### Breaking
 
 - JsonModel: `.get()` now uses the column's `where` and `whereVal` like `.search()` does. This means that it will return different results than in v3, but those cases were likely to be unintended.
+- EventQueue: `.setKnownV()` is now synchronous and no longer returns a Promise
 
 ## 3.2.1
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 ### Changes
 
+- ESDB: Added `transact({event, model, store, dispatch})` phase to the event processing flow. In this callback, you can call `dispatch` to generate and await sub-events, and calling ESModel will work too (any model can use the `dispatch` given via the constructor).
+  This requires the use of `AsyncLocalStorage`, and thus the minimum NodeJS version is now v12.17
 - SQLite: added `.runOnceOnOpen()` to register functions that should be run on the open database but shouldn't open the database
 - Renamed `dispatch()` to `addEvent()` inside the event processing flow. `dispatch()` still works but gives a deprecation warning. The `.dispatch()` method is not affected.
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,8 @@
 - ESDB: Added `transact({event, model, store, dispatch})` phase to the event processing flow. In this callback, you can call `dispatch` to generate and await sub-events, and calling ESModel will work too (any model can use the `dispatch` given via the constructor).
   This requires the use of `AsyncLocalStorage`, and thus the minimum NodeJS version is now v12.17
 - SQLite: added `.runOnceOnOpen()` to register functions that should be run on the open database but shouldn't open the database
-- Renamed `dispatch()` to `addEvent()` inside the event processing flow. `dispatch()` still works but gives a deprecation warning. The `.dispatch()` method is not affected.
+- ESDB: Renamed `dispatch()` to `addEvent()` inside the event processing flow. `dispatch()` still works but gives a deprecation warning. The `.dispatch()` method is not affected.
+- ESDB: `dispatch({type, data, ts})` (passing everything in a single argument) is now also possible, as well as for `addEvent`.
 
 ### Deprecations
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+
+- JsonModel: `.get()` now uses the column's `where` and `whereVal` like `.search()` does. This means that it will return different results than in v3, but those cases were likely to be unintended.
+
 ## 3.2.1
 
 - ESDB: fix rare race condition where read-only connection doesn't see just-committed transaction

--- a/Server Side Redux.md
+++ b/Server Side Redux.md
@@ -36,7 +36,7 @@ Basic ideas from [Turning The Database Inside Out](https://www.confluent.io/blog
     - any other keys: opaque data describing the change, can be informational or used by a custom `applyResult`
   - **Derivers**: Functions that calculate "secondary state" from the changes. They can serve to make the event result smaller
 - **History**: An ordered list of reduced events (so `{v, type, data, result}`). This is not required, and the event can be abridged. It could serve as an audit log. If all the original event data is retained, it can be used to reprocess the database from scratch.
-- **Sub-events**: To make the event processing code simpler, ESDB allows dispatching further events from anywhere in the redux cycle. These events are processed depth-first. For example, a USER_LOGIN event can result in a USER_REGISTERED event if they logged in via OAuth for the first time.
+- **Sub-events**: To make the event processing code simpler, ESDB allows adding derived events from anywhere in the redux cycle. These events are processed depth-first after normal event processing, inside the same transaction. For example, a USER_LOGIN event can result in a USER_REGISTERED event if they logged in via OAuth for the first time.
 
 ## Flow
 
@@ -76,7 +76,11 @@ Basic ideas from [Turning The Database Inside Out](https://www.confluent.io/blog
     - They change their models as they see fit
     - Failing derivers abort the transaction
   - **SubEvents**
-    - Each subevent undergoes these same steps in the same transaction, with the same version number.
+    - Each added subevent undergoes these same steps in the same transaction, with the same version number.
+  - **Transact**
+    - All `transact` callbacks are called sequentially in undefined order
+    - They receive a `dispatch` function that behaves like the `ESDB.dispatch` method but adds and waits for subevents
+    - This is an alternative to chaining reducer calls by adding subevents; a transact function keeps the logic together.
   - **End transaction**
     - The DB is now at the event version.
   - **Listeners**:

--- a/TODO.md
+++ b/TODO.md
@@ -99,7 +99,6 @@
 
 ### Important
 
-- [ ] make `.setKnownV` synchronous and apply the change on open or immediately if the DB is already open
 - [ ] allow marking an event as being processed, by setting worker id `where workerId is null` or something similar
 - [ ] workers should register in a table and write timestamps for a watchdog
 - [ ] while an event is being worked, next event can't be worked on.

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,7 @@
 
 ## General
 
+- Change the multi-access tests to use `"file:memdb1?mode=memory&cache=shared"` for shared access to the same in-memory db (probably when using better-sqlite, it requires file uri support)
 - Give DB and ESDB the same API for registering models (.addModel)
 - Optimize:
   - [ ] create benchmark
@@ -98,6 +99,7 @@
 
 ### Important
 
+- [ ] make `.setKnownV` synchronous and apply the change on open or immediately if the DB is already open
 - [ ] allow marking an event as being processed, by setting worker id `where workerId is null` or something similar
 - [ ] workers should register in a table and write timestamps for a watchdog
 - [ ] while an event is being worked, next event can't be worked on.
@@ -111,9 +113,9 @@
 
 ### Nice to have
 
+- [ ] provide event creators for each type of change
 - [ ] implement `.changeID`. It requires applyEvent to support `mv`
 - [ ] .get for the RO ESModel uses .getCached, with a caching-map limiting the amount, cleared when the version changes
-- [ ] .changeId (`mv:[[oldId, newId],…]` apply action?)
 
 ## ESDB
 
@@ -124,6 +126,8 @@
   - re-processing events clears all subsequent results
   - for multi-process, make the result db exclusive to worker
   - attach multiple result dbs for combined debug view
+- [ ] Add `transact` phase after the other phases, in which `dispatch` works as well as ESModel dispatches. This enables easier event handling with ESModel changes.
+- [ ] Add `beforeApply` phase which runs after all reducers ran so it has access to the state of the DB before the changes are applied.
 
 ### Nice to have
 

--- a/TODO.md
+++ b/TODO.md
@@ -53,6 +53,7 @@
 
 ### Important
 
+- `keepFalsy` option: normally, remove falsy (not '', 0), but with this, store them [breaking]
 - FTS5 support for text searching
   - Real columns marked `textSearch: true|string|object` generate a FTS5 index
   - one index per textSearch value ("tag")
@@ -116,8 +117,18 @@
 
 ## ESDB
 
+### Important
+
+- [ ] split queue in history (append-only) and results. The results are only for debugging and include one row per subevent and a diff vs the original data after preprocessing.
+  - Ideally, the results go in a different db that can be split at will.
+  - re-processing events clears all subsequent results
+  - for multi-process, make the result db exclusive to worker
+  - attach multiple result dbs for combined debug view
+
 ### Nice to have
 
+- [ ] add eventSpy, e.g. `eSDB.debug(boolean|{filter()})`
+- [ ] in non-prod, randomly run preprocessor twice (keep event in memory and restart handling) to verify repeatability
 - [ ] don't store empty result sub-events
 - [ ] `reducerByType` object keyed by type that gets the same arguments as preprocessor
   - same for preprocessor/deriver

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "email": "Wout.Mertens@gmail.com"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12.17"
   },
   "scripts": {
     "start": "nps",

--- a/src/DB/SQLite.js
+++ b/src/DB/SQLite.js
@@ -132,8 +132,11 @@ class SQLiteImpl extends EventEmitter {
 
 	sql = sql
 
+	/** @type {{fn: function; stack: string}[]} */
+	_queuedOnOpen = []
+
 	async _openDB() {
-		const {file, readOnly, _isChild, options, store} = this
+		const {file, readOnly, _isChild, _queuedOnOpen, options, store} = this
 		const {verbose, onWillOpen, onDidOpen, autoVacuum, vacuumInterval} = options
 
 		if (_isChild)
@@ -225,6 +228,20 @@ class SQLiteImpl extends EventEmitter {
 			this._optimizerToken.unref()
 
 			if (onDidOpen) await onDidOpen(childDb)
+			for (const {fn, stack} of this._queuedOnOpen) {
+				try {
+					// eslint-disable-next-line no-await-in-loop
+					await fn(childDb)
+				} catch (error) {
+					if (error?.message)
+						error.message = `in function queued ${stack?.replace(
+							/^(?:[^\n]*\n){2}\s*/m,
+							''
+						)}: ${error.message}`
+					throw error
+				}
+			}
+			this._queuedOnOpen.length = 0
 			await childDb.close()
 		}
 
@@ -236,6 +253,13 @@ class SQLiteImpl extends EventEmitter {
 	}
 
 	/**
+	 * `true` if an sqlite connection was set up. Mostly useful for tests.
+	 */
+	get isOpen() {
+		return Boolean(this._sqlite)
+	}
+
+	/**
 	 * Force opening the database instead of doing it lazily on first access.
 	 *
 	 * @returns {Promise<void>} - a promise for the DB being ready to use.
@@ -243,14 +267,34 @@ class SQLiteImpl extends EventEmitter {
 	open() {
 		const {_resolveDbP} = this
 		if (_resolveDbP) {
-			this._resolveDbP = null
-			this._dbP = this._openDB().then(result => {
-				_resolveDbP(result)
-				this._dbP = null
-				return result
+			this._openingDbP = this._openDB().finally(() => {
+				this._openingDbP = null
 			})
+			_resolveDbP(this._openingDbP)
+			this._resolveDbP = null
+			this.dbP.catch(() => this.close())
 		}
 		return this.dbP
+	}
+
+	/**
+	 * Runs the passed function once, either immediately if the connection is
+	 * already open, or when the database will be opened next.
+	 * Note that if the function runs immediately, its return value is returned.
+	 * If this is a Promise, it is the caller's responsibility to handle errors.
+	 * Otherwise, the function will be run once after onDidOpen, and errors will
+	 * cause the open to fail.
+	 *
+	 * @param {(db: SQLite)=>void} fn
+	 * @returns {*} Either the function return value or undefined.
+	 */
+	runOnceOnOpen(fn) {
+		if (this.isOpen) {
+			// note that async errors are not handled
+			return fn(this)
+		}
+		// eslint-disable-next-line unicorn/error-message
+		this._queuedOnOpen.push({fn, stack: new Error('').stack})
 	}
 
 	/**
@@ -259,24 +303,27 @@ class SQLiteImpl extends EventEmitter {
 	 * @returns {Promise<void>} - a promise for the DB being closed.
 	 */
 	async close() {
-		if (!this._isChild) dbg(`${this.name} closing`)
+		if (this._openingDbP) {
+			dbg(`${this.name} waiting for open to complete before closing`)
+			await this._openingDbP.catch(() => {})
+		}
+		if (!this._sqlite) return
+		const {_sqlite, _isChild} = this
+		this._sqlite = null
+		clearInterval(this._optimizerToken)
+		this._optimizerToken = null
+		clearInterval(this._vacuumToken)
+		this._vacuumToken = null
+
+		if (!_isChild) dbg(`${this.name} closing`)
 
 		this.dbP = new Promise(resolve => {
 			this._resolveDbP = resolve
 		})
-		if (this._optimizerToken) {
-			clearInterval(this._optimizerToken)
-			this._optimizerToken = null
-		}
-		if (this._vacuumToken) {
-			clearInterval(this._vacuumToken)
-			this._vacuumToken = null
-		}
-		const {_sqlite, statements, _isChild, _optimizerToken, _dbP} = this
-		this._sqlite = null
 
-		// eslint-disable-next-line no-await-in-loop
-		for (const stmt of Object.values(statements)) await stmt.finalize()
+		const stmts = Object.values(this.statements)
+		if (stmts.length)
+			await Promise.all(stmts.map(stmt => stmt.finalize().catch(() => {})))
 
 		// We only want to close our own statements, not the db
 		if (_isChild) {
@@ -284,8 +331,6 @@ class SQLiteImpl extends EventEmitter {
 			return
 		}
 
-		clearInterval(_optimizerToken)
-		if (_dbP) await _dbP
 		if (_sqlite) await this._call('close', [], _sqlite, this.name)
 		dbg(`${this.name} closed`)
 	}

--- a/src/DB/SQLite.test.js
+++ b/src/DB/SQLite.test.js
@@ -6,260 +6,301 @@ import SQLite, {sql, valToSql} from './SQLite'
 // eslint-disable-next-line no-promise-executor-return
 const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
 
-test('valToSql', () => {
-	expect(valToSql(true)).toBe('1')
-	expect(valToSql(false)).toBe('0')
-	expect(valToSql(0)).toBe('0')
-	expect(valToSql(5.4)).toBe('5.4')
-	expect(valToSql("h'i")).toBe("'h''i'")
-	expect(valToSql(null)).toBe('NULL')
-	expect(valToSql()).toBe('NULL')
-})
-
-test(`sql.quoteId`, () => {
-	expect(sql.quoteId('a"ha"h""a a a a"')).toBe('"a""ha""h""""a a a a"""')
-})
-test('sql`` values', () => {
-	const out = sql`values ${1}, ${'a'} bop`
-	expect(out).toEqual(['values ?, ? bop', [1, 'a']])
-	expect(sql`${5}`).toEqual(['?', [5]])
-})
-test('sql`` JSON', () => {
-	const json = sql` ${'meep'}JSON, ${'moop'}JSONs, ${7}JSON`
-	expect(json).toEqual([' ?, ?JSONs, ?', ['"meep"', 'moop', '7']])
-})
-test('sql`` ID', () => {
-	const out = sql`ids ${1}ID, ${2}IDs ${'a"meep"whee'}ID`
-	expect(out).toEqual(['ids "1", ?IDs "a""meep""whee"', [2]])
-})
-test('sql`` LIT', () => {
-	const out = sql`ids ${1}LIT, ${2}LITs ${'a"meep"whee'}LIT`
-	expect(out).toEqual(['ids 1, ?LITs a"meep"whee', [2]])
-})
-
-test('sql`` on DB/db/fns', async () => {
-	const db = new SQLite()
-	// eslint-disable-next-line import/no-named-as-default-member
-	expect(typeof SQLite.sql).toBe('function')
-	expect(typeof db.sql).toBe('function')
-	let p
-	expect(() => {
-		p = db.exec`CREATE TABLE ${'foo'}ID(id BLOB);`
-	}).not.toThrow()
-	await expect(p).resolves.not.toThrow()
-	expect(() => {
-		p = db.run`INSERT INTO ${'foo'}ID VALUES (${5})`
-	}).not.toThrow()
-	await expect(p).resolves.not.toThrow()
-	expect(() => {
-		p = db.get`SELECT * FROM ${'foo'}ID WHERE ${'id'}ID = ${5}`
-	}).not.toThrow()
-	const row = await p
-	expect(row.id).toBe(5)
-	await db.close()
-})
-
-test('creates DB', async () => {
-	const db = new SQLite()
-	expect(db.dbP).toBeInstanceOf(Promise)
-	const version = await db.get('SELECT sqlite_version()')
-	expect(version['sqlite_version()']).toBeTruthy()
-	expect(db.store).toEqual({})
-	await db.close()
-})
-
-test('readOnly', async () => {
-	const db = new SQLite({readOnly: true})
-	await expect(db.get('SELECT sqlite_version()')).resolves.toBeTruthy()
-	await expect(db.get('CREATE TABLE foo(id)')).rejects.toThrow(
-		'SQLITE_READONLY'
-	)
-	await db.close()
-})
-
-test('each()', async () => {
-	const db = new SQLite()
-	await db.exec(`
-		CREATE TABLE foo(hi NUMBER);
-		INSERT INTO foo VALUES (42);
-		INSERT INTO foo VALUES (43);
-	`)
-	const arr = []
-	await db.each(`SELECT * FROM foo`, ({hi}) => arr.push(hi))
-	expect(arr).toEqual([42, 43])
-	await db.close()
-})
-
-test('close()', async () => {
-	const db = new SQLite()
-	await db.exec(`
-		CREATE TABLE foo(hi NUMBER);
-		INSERT INTO foo VALUES (42);
-	`)
-	const {hi} = await db.get(`SELECT * FROM foo`)
-	expect(hi).toBe(42)
-	// This clears db because it's in memory only
-	await db.close()
-	await db.exec(`
-		CREATE TABLE foo(hi NUMBER);
-		INSERT INTO foo VALUES (43);
-	`)
-	const {hi: hi2} = await db.get(`SELECT * FROM foo`)
-	expect(hi2).toBe(43)
-	await db.close()
-})
-
-test('onWillOpen', async () => {
-	const fn = jest.fn()
-	const db = new SQLite({
-		onWillOpen: fn,
+describe('valToSql', () => {
+	test.each([
+		[true, '1'],
+		[false, '0'],
+		[0, '0'],
+		[5.4, '5.4'],
+		["h'i", "'h''i'"],
+		[null, 'NULL'],
+		[undefined, 'NULL'],
+	])('%p => %s', (input, out) => {
+		expect(valToSql(input)).toBe(out)
 	})
-	expect(fn).toHaveBeenCalledTimes(0)
-	await db.open()
-	expect(fn).toHaveBeenCalledTimes(1)
-	await db.close()
 })
 
-describe('withTransaction', () => {
+describe('sql helper function', () => {
+	test(`sql.quoteId`, () => {
+		expect(sql.quoteId('a"ha"h""a a a a"')).toBe('"a""ha""h""""a a a a"""')
+	})
+	test('sql`` values', () => {
+		const out = sql`values ${1}, ${'a'} bop`
+		expect(out).toEqual(['values ?, ? bop', [1, 'a']])
+		expect(sql`${5}`).toEqual(['?', [5]])
+	})
+	test('sql`` JSON', () => {
+		const json = sql` ${'meep'}JSON, ${'moop'}JSONs, ${7}JSON`
+		expect(json).toEqual([' ?, ?JSONs, ?', ['"meep"', 'moop', '7']])
+	})
+	test('sql`` ID', () => {
+		const out = sql`ids ${1}ID, ${2}IDs ${'a"meep"whee'}ID`
+		expect(out).toEqual(['ids "1", ?IDs "a""meep""whee"', [2]])
+	})
+	test('sql`` LIT', () => {
+		const out = sql`ids ${1}LIT, ${2}LITs ${'a"meep"whee'}LIT`
+		expect(out).toEqual(['ids 1, ?LITs a"meep"whee', [2]])
+	})
+
+	test('sql`` on DB/db/fns', async () => {
+		const db = new SQLite()
+		// eslint-disable-next-line import/no-named-as-default-member
+		expect(typeof SQLite.sql).toBe('function')
+		expect(typeof db.sql).toBe('function')
+		let p
+		expect(() => {
+			p = db.exec`CREATE TABLE ${'foo'}ID(id BLOB);`
+		}).not.toThrow()
+		await expect(p).resolves.not.toThrow()
+		expect(() => {
+			p = db.run`INSERT INTO ${'foo'}ID VALUES (${5})`
+		}).not.toThrow()
+		await expect(p).resolves.not.toThrow()
+		expect(() => {
+			p = db.get`SELECT * FROM ${'foo'}ID WHERE ${'id'}ID = ${5}`
+		}).not.toThrow()
+		const row = await p
+		expect(row.id).toBe(5)
+		await db.close()
+	})
+})
+
+const expectSqliteWorks = async db =>
+	expect(await db.get('SELECT sqlite_version() AS v')).toHaveProperty('v')
+
+describe('SQLite', () => {
 	test('works', async () => {
 		const db = new SQLite()
-		await db.exec`CREATE TABLE foo(hi INTEGER PRIMARY KEY, ho INT);`
-		expect(db.inTransaction).toBe(false)
-		db.withTransaction(async () => {
-			expect(db.inTransaction).toBe(true)
-			await wait(100)
-			await db.exec`INSERT INTO foo VALUES (43, 1);`
-		})
-		expect(db.inTransaction).toBe(false)
-		await db.withTransaction(
-			() => db.exec`UPDATE foo SET ho = 2 where hi = 43;`
-		)
-		expect(await db.all`SELECT * from foo`).toEqual([{hi: 43, ho: 2}])
+		await expectSqliteWorks(db)
+		expect(db.dbP).toBeInstanceOf(Promise)
+		expect(db.store).toEqual({})
 		await db.close()
 	})
 
-	test('rollback works', async () => {
+	test('10 simultaneous opens', async () => {
+		tmp.withDir(
+			async ({path: dir}) => {
+				const file = sysPath.join(dir, 'db')
+				const db = new SQLite({file})
+				await db.exec('CREATE TABLE t(id, v); INSERT INTO t VALUES(1, 0);')
+
+				const openClose = async () => {
+					const extraDb = new SQLite({file})
+					await extraDb.open()
+					await extraDb.exec('UPDATE t SET v=v+1 WHERE id=1')
+					await extraDb.close()
+				}
+				const Ps = []
+				for (let i = 0; i < 10; i++) {
+					Ps.push(openClose())
+				}
+				await Promise.all(Ps)
+				expect(await db.get('SELECT v from t')).toHaveProperty('v', 10)
+			},
+			{unsafeCleanup: true, prefix: 'sq-open'}
+		)
+	})
+	test('.close()', async () => {
 		const db = new SQLite()
-		await db.exec`CREATE TABLE foo(hi INTEGER PRIMARY KEY, ho INT);`
-		expect(db.inTransaction).toBe(false)
-		await expect(
+		await db.exec(`
+		CREATE TABLE foo(hi NUMBER);
+		INSERT INTO foo VALUES (42);
+	`)
+		const {hi} = await db.get(`SELECT * FROM foo`)
+		expect(hi).toBe(42)
+		// This clears db because it's in memory only
+		await db.close()
+		await db.exec(`
+		CREATE TABLE foo(hi NUMBER);
+		INSERT INTO foo VALUES (43);
+	`)
+		const {hi: hi2} = await db.get(`SELECT * FROM foo`)
+		expect(hi2).toBe(43)
+		await db.close()
+	})
+
+	describe('options', () => {
+		test('readOnly', async () => {
+			const db = new SQLite({readOnly: true})
+			await expectSqliteWorks(db)
+			await expect(db.get('CREATE TABLE foo(id)')).rejects.toThrow(
+				'SQLITE_READONLY'
+			)
+			await db.close()
+		})
+
+		test('onWillOpen', async () => {
+			const fn = jest.fn()
+			const db = new SQLite({
+				onWillOpen: fn,
+			})
+			expect(fn).toHaveBeenCalledTimes(0)
+			await db.open()
+			expect(fn).toHaveBeenCalledTimes(1)
+			await db.close()
+		})
+	})
+
+	describe('.withTransaction()', () => {
+		test('works', async () => {
+			const db = new SQLite()
+			await db.exec`CREATE TABLE foo(hi INTEGER PRIMARY KEY, ho INT);`
+			expect(db.inTransaction).toBe(false)
 			db.withTransaction(async () => {
 				expect(db.inTransaction).toBe(true)
+				await wait(100)
 				await db.exec`INSERT INTO foo VALUES (43, 1);`
-				throw new Error('ignoreme')
 			})
-		).rejects.toThrow('ignoreme')
-		expect(db.inTransaction).toBe(false)
-		expect(await db.all`SELECT * from foo`).toEqual([])
+			expect(db.inTransaction).toBe(false)
+			await db.withTransaction(
+				() => db.exec`UPDATE foo SET ho = 2 where hi = 43;`
+			)
+			expect(await db.all`SELECT * from foo`).toEqual([{hi: 43, ho: 2}])
+			await db.close()
+		})
+
+		test('rollback works', async () => {
+			const db = new SQLite()
+			await db.exec`CREATE TABLE foo(hi INTEGER PRIMARY KEY, ho INT);`
+			expect(db.inTransaction).toBe(false)
+			await expect(
+				db.withTransaction(async () => {
+					expect(db.inTransaction).toBe(true)
+					await db.exec`INSERT INTO foo VALUES (43, 1);`
+					throw new Error('ignoreme')
+				})
+			).rejects.toThrow('ignoreme')
+			expect(db.inTransaction).toBe(false)
+			expect(await db.all`SELECT * from foo`).toEqual([])
+			await db.close()
+		})
+
+		test('emits', async () => {
+			const db = new SQLite()
+			const begin = jest.fn()
+			const end = jest.fn()
+			const rollback = jest.fn()
+			const fnl = jest.fn()
+			db.on('begin', begin)
+			db.on('end', end)
+			db.on('rollback', rollback)
+			db.on('finally', fnl)
+			await db.withTransaction(() => {
+				expect(begin).toHaveBeenCalled()
+				expect(rollback).not.toHaveBeenCalled()
+				expect(end).not.toHaveBeenCalled()
+				expect(fnl).not.toHaveBeenCalled()
+			})
+			expect(begin).toHaveBeenCalledTimes(1)
+			expect(rollback).not.toHaveBeenCalled()
+			expect(end).toHaveBeenCalledTimes(1)
+			expect(fnl).toHaveBeenCalledTimes(1)
+			await db
+				.withTransaction(() => {
+					expect(begin).toHaveBeenCalledTimes(2)
+					expect(rollback).not.toHaveBeenCalled()
+					expect(end).toHaveBeenCalledTimes(1)
+					expect(fnl).toHaveBeenCalledTimes(1)
+					// eslint-disable-next-line no-throw-literal
+					throw 'foo'
+				})
+				.catch(e => {
+					if (e !== 'foo') throw e
+					expect(rollback).toHaveBeenCalledTimes(1)
+					expect(end).toHaveBeenCalledTimes(1)
+					expect(fnl).toHaveBeenCalledTimes(2)
+				})
+		})
+	})
+
+	test('.dataVersion()', () =>
+		tmp.withDir(
+			async ({path: dir}) => {
+				const file = sysPath.join(dir, 'db')
+				const db1 = new SQLite({file})
+				const db2 = new SQLite({file})
+				const v1 = await db1.dataVersion()
+				const v2 = await db2.dataVersion()
+				await db1.exec`SELECT 1;`
+				expect(await db1.dataVersion()).toBe(v1)
+				expect(await db2.dataVersion()).toBe(v2)
+				await db1.exec`CREATE TABLE foo(hi INTEGER PRIMARY KEY, ho INT);`
+				expect(await db1.dataVersion()).toBe(v1)
+				const v2b = await db2.dataVersion()
+				expect(v2b).toBeGreaterThan(v2)
+				await db2.exec`INSERT INTO foo VALUES (43, 1);`
+				expect(await db1.dataVersion()).toBeGreaterThan(v1)
+				expect(await db2.dataVersion()).toBe(v2b)
+				await db1.close()
+				await db2.close()
+			},
+			{unsafeCleanup: true, prefix: 'sq-data'}
+		))
+
+	test('.userVersion()', async () => {
+		const db = new SQLite()
+		await expect(db.userVersion()).resolves.toBe(0)
+		await expect(db.userVersion(5)).resolves.toBe()
+		await expect(db.userVersion()).resolves.toBe(5)
+	})
+
+	test('.each()', async () => {
+		const db = new SQLite()
+		await db.exec(
+			`CREATE TABLE foo(hi NUMBER); INSERT INTO foo VALUES (42),(43);`
+		)
+		const arr = []
+		await db.each(`SELECT * FROM foo`, ({hi}) => arr.push(hi))
+		expect(arr).toEqual([42, 43])
 		await db.close()
 	})
 
-	test('emits', async () => {
-		const db = new SQLite()
-		const begin = jest.fn()
-		const end = jest.fn()
-		const rollback = jest.fn()
-		const fnl = jest.fn()
-		db.on('begin', begin)
-		db.on('end', end)
-		db.on('rollback', rollback)
-		db.on('finally', fnl)
-		await db.withTransaction(() => {
-			expect(begin).toHaveBeenCalled()
-			expect(rollback).not.toHaveBeenCalled()
-			expect(end).not.toHaveBeenCalled()
-			expect(fnl).not.toHaveBeenCalled()
+	describe('error handling', () => {
+		test('open: errors with filename', async () => {
+			const db = new SQLite({file: '/oienu/ieoienien'})
+			await expect(db._openDB()).rejects.toThrow('/oienu/ieoienien')
 		})
-		expect(begin).toHaveBeenCalledTimes(1)
-		expect(rollback).not.toHaveBeenCalled()
-		expect(end).toHaveBeenCalledTimes(1)
-		expect(fnl).toHaveBeenCalledTimes(1)
-		await db
-			.withTransaction(() => {
-				expect(begin).toHaveBeenCalledTimes(2)
-				expect(rollback).not.toHaveBeenCalled()
-				expect(end).toHaveBeenCalledTimes(1)
-				expect(fnl).toHaveBeenCalledTimes(1)
-				// eslint-disable-next-line no-throw-literal
-				throw 'foo'
-			})
-			.catch(e => {
-				if (e !== 'foo') throw e
-				expect(rollback).toHaveBeenCalledTimes(1)
-				expect(end).toHaveBeenCalledTimes(1)
-				expect(fnl).toHaveBeenCalledTimes(2)
-			})
+
+		test('SQLite methods: errors with filename', async () => {
+			const db = new SQLite()
+			await expect(db.run('bad sql haha')).rejects.toHaveProperty(
+				'code',
+				'SQLITE_ERROR'
+			)
+			await expect(db.run('bad sql haha')).rejects.toThrow(':memory:')
+			await expect(db.get('bad sql haha')).rejects.toThrow(':memory:')
+			await expect(db.all('bad sql haha')).rejects.toThrow(':memory:')
+			await expect(db.exec('bad sql haha')).rejects.toThrow(':memory:')
+			await expect(db.each('bad sql haha')).rejects.toThrow(':memory:')
+			await expect(db.prepare('bad sql haha').get()).rejects.toThrow(':memory:')
+			await db.close()
+		})
 	})
-})
 
-test('dataVersion', () =>
-	tmp.withDir(
-		async ({path: dir}) => {
-			const file = sysPath.join(dir, 'db')
-			const db1 = new SQLite({file})
-			const db2 = new SQLite({file})
-			const v1 = await db1.dataVersion()
-			const v2 = await db2.dataVersion()
-			await db1.exec`SELECT 1;`
-			expect(await db1.dataVersion()).toBe(v1)
-			expect(await db2.dataVersion()).toBe(v2)
-			await db1.exec`CREATE TABLE foo(hi INTEGER PRIMARY KEY, ho INT);`
-			expect(await db1.dataVersion()).toBe(v1)
-			const v2b = await db2.dataVersion()
-			expect(v2b).toBeGreaterThan(v2)
-			await db2.exec`INSERT INTO foo VALUES (43, 1);`
-			expect(await db1.dataVersion()).toBeGreaterThan(v1)
-			expect(await db2.dataVersion()).toBe(v2b)
-			await db1.close()
-			await db2.close()
-		},
-		{unsafeCleanup: true, prefix: 'sq-data'}
-	))
+	describe('vacuum', () => {
+		test('works', async () => {
+			const db = new SQLite({autoVacuum: true})
+			expect(await db.get('PRAGMA auto_vacuum')).toHaveProperty(
+				'auto_vacuum',
+				2
+			)
+			expect(db._vacuumToken).toBeDefined()
+			await db.close()
+			expect(db._vacuumToken).toBeFalsy()
+			const db2 = new SQLite()
+			await db2.open()
+			expect(await db2.get('PRAGMA auto_vacuum')).toHaveProperty(
+				'auto_vacuum',
+				0
+			)
+		})
 
-test('userVersion', async () => {
-	const db = new SQLite()
-	await expect(db.userVersion()).resolves.toBe(0)
-	await expect(db.userVersion(5)).resolves.toBe()
-	await expect(db.userVersion()).resolves.toBe(5)
-})
-
-test('open: errors with filename', async () => {
-	const db = new SQLite({file: '/oienu/ieoienien'})
-	await expect(db._openDB()).rejects.toThrow('/oienu/ieoienien')
-})
-
-test('SQLite methods: errors with filename', async () => {
-	const db = new SQLite()
-	await expect(db.run('bad sql haha')).rejects.toHaveProperty(
-		'code',
-		'SQLITE_ERROR'
-	)
-	await expect(db.run('bad sql haha')).rejects.toThrow(':memory:')
-	await expect(db.get('bad sql haha')).rejects.toThrow(':memory:')
-	await expect(db.all('bad sql haha')).rejects.toThrow(':memory:')
-	await expect(db.exec('bad sql haha')).rejects.toThrow(':memory:')
-	await expect(db.each('bad sql haha')).rejects.toThrow(':memory:')
-	await expect(db.prepare('bad sql haha').get()).rejects.toThrow(':memory:')
-	await db.close()
-})
-
-test('vacuum', async () => {
-	const db = new SQLite({autoVacuum: true})
-	expect(await db.get('PRAGMA auto_vacuum')).toHaveProperty('auto_vacuum', 2)
-	expect(db._vacuumToken).toBeDefined()
-	await db.close()
-	expect(db._vacuumToken).toBeFalsy()
-	const db2 = new SQLite()
-	await db2.open()
-	expect(await db2.get('PRAGMA auto_vacuum')).toHaveProperty('auto_vacuum', 0)
-})
-
-test('incrementally vacuum', async () =>
-	tmp.withDir(
-		async ({path: dir}) => {
-			const file = sysPath.join(dir, 'db')
-			const db = new SQLite({file, autoVacuum: true, vacuumPageCount: 1})
-			await db.exec(`
+		test('incrementally vacuum', async () =>
+			tmp.withDir(
+				async ({path: dir}) => {
+					const file = sysPath.join(dir, 'db')
+					const db = new SQLite({file, autoVacuum: true, vacuumPageCount: 1})
+					await db.exec(`
 				CREATE TABLE test(field1);
 
 				INSERT INTO test
@@ -275,39 +316,17 @@ test('incrementally vacuum', async () =>
 
 				DELETE FROM test;
 			`)
-			const getLeft = async () => {
-				const {freelist_count: left} = await db.get('PRAGMA freelist_count')
-				return left
-			}
-			const left1 = await getLeft()
-			expect(await getLeft()).toBeGreaterThan(20)
-			await db._vacuumStep()
-			expect(await getLeft()).toBeLessThan(left1)
-			await db.close()
-		},
-		{unsafeCleanup: true, prefix: 'iv'}
-	))
-
-test('10 simultaneous opens', async () => {
-	tmp.withDir(
-		async ({path: dir}) => {
-			const file = sysPath.join(dir, 'db')
-			const db = new SQLite({file})
-			await db.exec('CREATE TABLE t(id, v); INSERT INTO t VALUES(1, 0);')
-
-			const openClose = async () => {
-				const extraDb = new SQLite({file})
-				await extraDb.open()
-				await extraDb.exec('UPDATE t SET v=v+1 WHERE id=1')
-				await extraDb.close()
-			}
-			const Ps = []
-			for (let i = 0; i < 10; i++) {
-				Ps.push(openClose())
-			}
-			await Promise.all(Ps)
-			expect(await db.get('SELECT v from t')).toHaveProperty('v', 10)
-		},
-		{unsafeCleanup: true, prefix: 'sq-open'}
-	)
+					const getLeft = async () => {
+						const {freelist_count: left} = await db.get('PRAGMA freelist_count')
+						return left
+					}
+					const left1 = await getLeft()
+					expect(await getLeft()).toBeGreaterThan(20)
+					await db._vacuumStep()
+					expect(await getLeft()).toBeLessThan(left1)
+					await db.close()
+				},
+				{unsafeCleanup: true, prefix: 'iv'}
+			))
+	})
 })

--- a/src/DB/Statement.js
+++ b/src/DB/Statement.js
@@ -38,7 +38,7 @@ class StatementImpl {
 	 */
 	_wrap(fn) {
 		if (!this._stmt) this.P = this.P.then(this._refresh)
-		this.P = this.P.then(fn, fn)
+		this.P = this.P.then(fn)
 		return this.P
 	}
 

--- a/src/EventQueue.js
+++ b/src/EventQueue.js
@@ -260,18 +260,26 @@ class EventQueueImpl extends JsonModel {
 	 *
 	 * @param {number} v  - the last known version.
 	 */
-	async setKnownV(v) {
+	setKnownV(v) {
 		// set the sqlite autoincrement value
 		// Try changing current value, and insert if there was no change
-		// This doesn't need a transaction, either one or the other runs
-		// TODO alsoLower flag and only update where seq < v
-		await this.db.exec(
-			`
-				UPDATE sqlite_sequence SET seq = ${v} WHERE name = ${this.quoted};
-				INSERT INTO sqlite_sequence (name, seq)
-					SELECT ${this.quoted}, ${v} WHERE NOT EXISTS
-						(SELECT changes() AS change FROM sqlite_sequence WHERE change <> 0);
-			`
+		// This doesn't need a transaction, either one or the other runs and
+		// both are sent in the same command so nothing will run in between
+		this.db.runOnceOnOpen(db =>
+			db
+				.exec(
+					`
+					UPDATE sqlite_sequence SET seq = ${v} WHERE name = ${this.quoted};
+					INSERT INTO sqlite_sequence (name, seq)
+						SELECT ${this.quoted}, ${v} WHERE NOT EXISTS
+							(SELECT changes() AS change FROM sqlite_sequence WHERE change <> 0);
+				`
+				)
+				.catch(error => {
+					// eslint-disable-next-line no-console
+					console.error(`setKnownV: could not update sequence`, error)
+					db.close()
+				})
 		)
 		this.currentV = Math.max(this.currentV, v)
 		this.knownV = v

--- a/src/EventSourcingDB/ESDB-concurrency.test.js
+++ b/src/EventSourcingDB/ESDB-concurrency.test.js
@@ -21,11 +21,11 @@ const testModels = {
 			expect(model).toBe(store.subber)
 			if (event.type === 'sub') expect(await model.get('hey')).toBeTruthy()
 		},
-		reducer: async ({model, event: {type}, dispatch, store}) => {
+		reducer: async ({model, event: {type}, addEvent, store}) => {
 			expect(model).toBe(store.subber)
 			switch (type) {
 				case 'main':
-					dispatch('sub')
+					addEvent('sub')
 					return {ins: [{id: 'hey'}]}
 				case 'sub':
 					expect(await model.get('hey')).toBeTruthy()
@@ -52,7 +52,7 @@ const testModels = {
 	},
 	nexter: {
 		columns: {id: {type: 'INTEGER'}},
-		reducer: async ({model, event: {type, data}, dispatch}) => {
+		reducer: async ({model, event: {type, data}, addEvent}) => {
 			if (type !== 'nexter') return
 			const id = await model.getNextId()
 			await model.getNextId() // skip an id
@@ -60,7 +60,7 @@ const testModels = {
 			// skip an id, shouldn't matter
 			await model.getNextId()
 			if (data) {
-				dispatch('nexter', data - 1)
+				addEvent('nexter', data - 1)
 			}
 			return {ins: [{id}, {id: id2}]}
 		},

--- a/src/EventSourcingDB/ESDB-create.test.js
+++ b/src/EventSourcingDB/ESDB-create.test.js
@@ -9,239 +9,244 @@ const events = [
 	{v: 2, type: 'bar', data: {gotBar: true}},
 ]
 
-test('create', () =>
-	tmp.withDir(
-		async ({path: dir}) => {
-			const file = sysPath.join(dir, 'db')
-			const queueFile = sysPath.join(dir, 'q')
-			const eSDB = new ESDB({
-				file,
-				queueFile,
-				name: 'E',
-				models: testModels,
-			})
-			// eSDB.listen(changes => eSDB.reducers.count.get('count'))
-			expect(eSDB.db).toBeTruthy()
-			expect(eSDB.rwDb).toBeTruthy()
-			expect(eSDB.queue).toBeTruthy()
-			expect(eSDB.models).toBeUndefined()
-			expect(eSDB.store.count).toBeTruthy()
-			expect(eSDB.rwStore.count).toBeTruthy()
-			// Make sure the read-only database can start (no timeout)
-			// and that migrations work
-			expect(await eSDB.store.count.all()).toEqual([
-				{id: 'count', total: 0, byType: {}},
-			])
-		},
-		{unsafeCleanup: true, prefix: 'esdb-create'}
-	))
+describe('ESDB create', () => {
+	test('works', () =>
+		tmp.withDir(
+			async ({path: dir}) => {
+				const file = sysPath.join(dir, 'db')
+				const queueFile = sysPath.join(dir, 'q')
+				const eSDB = new ESDB({
+					file,
+					queueFile,
+					name: 'E',
+					models: testModels,
+				})
+				// eSDB.listen(changes => eSDB.reducers.count.get('count'))
+				expect(eSDB.db).toBeTruthy()
+				expect(eSDB.rwDb).toBeTruthy()
+				expect(eSDB.queue).toBeTruthy()
+				expect(eSDB.models).toBeUndefined()
+				expect(eSDB.store.count).toBeTruthy()
+				expect(eSDB.rwStore.count).toBeTruthy()
+				// Make sure the read-only database can start (no timeout)
+				// and that migrations work
+				expect(await eSDB.store.count.all()).toEqual([
+					{id: 'count', total: 0, byType: {}},
+				])
+			},
+			{unsafeCleanup: true, prefix: 'esdb-create'}
+		))
 
-test('create with existing version', () =>
-	tmp.withDir(
-		async ({path: dir}) => {
-			const file = sysPath.join(dir, 'db')
-			const db = new DB({file})
-			await db.userVersion(100)
-			const queueFile = sysPath.join(dir, 'q')
-			const eSDB = new ESDB({
-				file,
-				queueFile,
-				name: 'E',
-				models: testModels,
-			})
-			// Note that this only works if you open the db first
-			await eSDB.waitForQueue()
-			const e = await eSDB.dispatch('hi')
-			expect(e.v).toBe(101)
-		},
-		{unsafeCleanup: true}
-	))
+	test('with existing version', () =>
+		tmp.withDir(
+			async ({path: dir}) => {
+				const file = sysPath.join(dir, 'db')
+				const db = new DB({file})
+				await db.userVersion(100)
+				const queueFile = sysPath.join(dir, 'q')
+				const eSDB = new ESDB({
+					file,
+					queueFile,
+					name: 'E',
+					models: testModels,
+				})
+				// Note that this only works if you open the db first
+				await eSDB.waitForQueue()
+				const e = await eSDB.dispatch('hi')
+				expect(e.v).toBe(101)
+			},
+			{unsafeCleanup: true}
+		))
 
-test('create in single file', async () => {
-	const eSDB = new ESDB({
-		name: 'E',
-		models: testModels,
+	test('in single file', async () => {
+		const eSDB = new ESDB({
+			name: 'E',
+			models: testModels,
+		})
+		// eSDB.listen(changes => eSDB.reducers.count.get('count'))
+		expect(eSDB.db).toBeTruthy()
+		expect(eSDB.rwDb).toBeTruthy()
+		expect(eSDB.queue).toBeTruthy()
+		expect(eSDB.models).toBeUndefined()
+		expect(eSDB.store.count).toBeTruthy()
+		expect(eSDB.rwStore.count).toBeTruthy()
+		// Make sure the read-only database can start (no timeout)
+		// and that migrations work
+		expect(await eSDB.store.count.all()).toEqual([
+			{id: 'count', total: 0, byType: {}},
+		])
 	})
-	// eSDB.listen(changes => eSDB.reducers.count.get('count'))
-	expect(eSDB.db).toBeTruthy()
-	expect(eSDB.rwDb).toBeTruthy()
-	expect(eSDB.queue).toBeTruthy()
-	expect(eSDB.models).toBeUndefined()
-	expect(eSDB.store.count).toBeTruthy()
-	expect(eSDB.rwStore.count).toBeTruthy()
-	// Make sure the read-only database can start (no timeout)
-	// and that migrations work
-	expect(await eSDB.store.count.all()).toEqual([
-		{id: 'count', total: 0, byType: {}},
-	])
+
+	test('with Model', () => {
+		return withESDB(
+			{
+				count: {
+					Model: class Count extends JsonModel {
+						constructor(options) {
+							if (typeof options.dispatch !== 'function') {
+								throw new TypeError('Dispatch expected')
+							}
+							if (typeof options.emitter !== 'object') {
+								throw new TypeError('emitter expected')
+							}
+							delete options.emitter
+							super(options)
+						}
+
+						foo() {
+							return true
+						}
+					},
+					reducer: testModels.count.reducer,
+				},
+			},
+			eSDB => {
+				expect(eSDB.store.count.foo()).toBe(true)
+			}
+		)
+	})
+
+	test('without given queue', async () => {
+		let eSDB
+		expect(() => {
+			eSDB = new ESDB({models: {}})
+		}).not.toThrow()
+		await expect(eSDB.dispatch('hi')).resolves.toHaveProperty('v', 1)
+	})
 })
 
-test('create with Model', () => {
-	return withESDB(
-		eSDB => {
-			expect(eSDB.store.count.foo()).toBe(true)
-		},
-		{
-			count: {
-				Model: class Count extends JsonModel {
-					constructor(options) {
-						if (typeof options.dispatch !== 'function') {
-							throw new TypeError('Dispatch expected')
-						}
-						if (typeof options.emitter !== 'object') {
-							throw new TypeError('emitter expected')
-						}
-						delete options.emitter
-						super(options)
-					}
-
-					foo() {
-						return true
-					}
+describe('redux cycle', () => {
+	test('reducer works', () => {
+		return withESDB(async eSDB => {
+			const result = await eSDB._reducer({}, events[0])
+			expect(result).toEqual({
+				v: 1,
+				type: 'foo',
+				result: {
+					count: {set: [{id: 'count', total: 1, byType: {foo: 1}}]},
 				},
-				reducer: testModels.count.reducer,
+			})
+			const result2 = await eSDB._reducer({}, events[1])
+			expect(result2).toEqual({
+				v: 2,
+				type: 'bar',
+				data: {gotBar: true},
+				result: {
+					count: {set: [{id: 'count', total: 1, byType: {bar: 1}}]},
+				},
+			})
+		})
+	})
+
+	test('preprocess changes pass to reduce', () => {
+		const models = {
+			foo: {
+				preprocessor: ({event}) => {
+					if (event.type !== 'meep') return
+					return {...event, step: 1}
+				},
+				reducer: ({event}) => {
+					if (event.type !== 'meep') return
+					expect(event).toHaveProperty('step', 1)
+				},
 			},
 		}
-	)
-})
-
-test('create without given queue', async () => {
-	let eSDB
-	expect(() => {
-		eSDB = new ESDB({models: {}})
-	}).not.toThrow()
-	await expect(eSDB.dispatch('hi')).resolves.toHaveProperty('v', 1)
-})
-
-test('reducer', () => {
-	return withESDB(async eSDB => {
-		const result = await eSDB._reducer({}, events[0])
-		expect(result).toEqual({
-			v: 1,
-			type: 'foo',
-			result: {
-				count: {set: [{id: 'count', total: 1, byType: {foo: 1}}]},
-			},
-		})
-		const result2 = await eSDB._reducer({}, events[1])
-		expect(result2).toEqual({
-			v: 2,
-			type: 'bar',
-			data: {gotBar: true},
-			result: {
-				count: {set: [{id: 'count', total: 1, byType: {bar: 1}}]},
-			},
+		return withESDB(models, async eSDB => {
+			await eSDB.dispatch('meep')
 		})
 	})
 })
 
-test('preprocess => reduce', () => {
-	const models = {
-		foo: {
-			preprocessor: ({event}) => {
-				if (event.type !== 'meep') return
-				return {...event, step: 1}
-			},
-			reducer: ({event}) => {
-				if (event.type !== 'meep') return
-				expect(event).toHaveProperty('step', 1)
-			},
-		},
-	}
-	return withESDB(async eSDB => {
-		await eSDB.dispatch('meep')
-	}, models)
-})
-
-test('reducer migration support', async () => {
-	let step = 0
-	return withESDB(
-		async eSDB => {
-			// Wait for migrations to run
-			await eSDB.store.count.searchOne()
-			expect(step).toBe(1)
-			const e = await eSDB.queue.searchOne()
-			expect(e.type).toBe('foo')
-		},
-		{
-			count: {
-				...testModels.count,
-				migrations: {
-					async foo({db, model, queue}) {
-						expect(step).toBe(0)
-						step = 1
-						expect(db).toBeTruthy()
-						expect(model).toBeTruthy()
-						expect(queue).toBeTruthy()
-						await queue.add('foo', 0)
+describe('ESDB migrations', () => {
+	test('model migrations get queue', async () => {
+		let step = 0
+		return withESDB(
+			{
+				count: {
+					...testModels.count,
+					migrations: {
+						async foo({db, model, queue}) {
+							expect(step).toBe(0)
+							step = 1
+							expect(db).toBeTruthy()
+							expect(model).toBeTruthy()
+							expect(queue).toBeTruthy()
+							await queue.add('foo', 0)
+						},
 					},
 				},
 			},
-		}
-	)
-})
-
-test('metadata migration', async () => {
-	class M extends JsonModel {
-		constructor({emitter: _1, ...props}) {
-			super({
-				...props,
-				migrations: {
-					...props.migrations,
-					1: async ({model}) => model.set({id: 'version', v: 5}),
-				},
-			})
-		}
-
-		// eslint-disable-next-line no-unused-vars
-		static reducer(args) {}
-	}
-	const eSDB = new ESDB({
-		models: {metadata: {Model: M}},
+			async eSDB => {
+				await eSDB.open()
+				expect(step).toBe(1)
+				const e = await eSDB.queue.searchOne()
+				expect(e.type).toBe('foo')
+			}
+		)
 	})
-	// Version should be moved to user_version
-	expect(await eSDB.db.get('PRAGMA user_version')).toHaveProperty(
-		'user_version',
-		5
-	)
-	// metadata table should be gone
-	expect(
-		await eSDB.db.get('SELECT * FROM sqlite_master WHERE name="metadata"')
-	).toBeFalsy()
-})
 
-test('metadata migration with existing data', async () => {
-	class M extends JsonModel {
-		constructor({emitter: _1, ...props}) {
-			super({
-				...props,
-				migrations: {
-					...props.migrations,
-					1: async ({model}) => {
-						await model.set({id: 'version', v: 5})
-						await model.set({id: 'hi'})
+	test('metadata migration', async () => {
+		class M extends JsonModel {
+			constructor({emitter: _1, ...props}) {
+				super({
+					...props,
+					migrations: {
+						...props.migrations,
+						1: async ({model}) => model.set({id: 'version', v: 5}),
 					},
-				},
-			})
-		}
+				})
+			}
 
-		// eslint-disable-next-line no-unused-vars
-		static reducer(args) {}
-	}
-	const eSDB = new ESDB({
-		models: {metadata: {Model: M}},
+			// eslint-disable-next-line no-unused-vars
+			static reducer(args) {}
+		}
+		const eSDB = new ESDB({
+			models: {metadata: {Model: M}},
+		})
+		// Version should be moved to user_version
+		expect(await eSDB.db.get('PRAGMA user_version')).toHaveProperty(
+			'user_version',
+			5
+		)
+		// metadata table should be gone
+		expect(
+			await eSDB.db.get('SELECT * FROM sqlite_master WHERE name="metadata"')
+		).toBeFalsy()
 	})
-	// Version should be moved to user_version
-	expect(await eSDB.db.get('PRAGMA user_version')).toHaveProperty(
-		'user_version',
-		5
-	)
-	// metadata table should still be there
-	expect(
-		await eSDB.db.get('SELECT * FROM sqlite_master WHERE name="metadata"')
-	).toBeTruthy()
-	// but version should be gone
-	expect(
-		await eSDB.db.get('SELECT * FROM metadata WHERE id="version"')
-	).toBeFalsy()
+
+	test('metadata migration with existing data', async () => {
+		class M extends JsonModel {
+			constructor({emitter: _1, ...props}) {
+				super({
+					...props,
+					migrations: {
+						...props.migrations,
+						1: async ({model}) => {
+							await model.set({id: 'version', v: 5})
+							await model.set({id: 'hi'})
+						},
+					},
+				})
+			}
+
+			// eslint-disable-next-line no-unused-vars
+			static reducer(args) {}
+		}
+		const eSDB = new ESDB({
+			models: {metadata: {Model: M}},
+		})
+		// Version should be moved to user_version
+		expect(await eSDB.db.get('PRAGMA user_version')).toHaveProperty(
+			'user_version',
+			5
+		)
+		// metadata table should still be there
+		expect(
+			await eSDB.db.get('SELECT * FROM sqlite_master WHERE name="metadata"')
+		).toBeTruthy()
+		// but version should be gone
+		expect(
+			await eSDB.db.get('SELECT * FROM metadata WHERE id="version"')
+		).toBeFalsy()
+	})
 })

--- a/src/EventSourcingDB/ESDB-events.test.js
+++ b/src/EventSourcingDB/ESDB-events.test.js
@@ -1,93 +1,68 @@
 import {withESDB} from '../lib/_test-helpers'
 
-test('applyEvent', () => {
-	return withESDB(async eSDB => {
-		await eSDB.db.withTransaction(() =>
-			eSDB._applyEvent(
-				{
-					v: 50,
-					type: 'foo',
-					result: {
-						count: {set: [{id: 'count', total: 1, byType: {foo: 1}}]},
+describe('ESDB events', () => {
+	test('applyEvent', () => {
+		return withESDB(async eSDB => {
+			await eSDB.db.withTransaction(() =>
+				eSDB._applyEvent(
+					{
+						v: 50,
+						type: 'foo',
+						result: {
+							count: {set: [{id: 'count', total: 1, byType: {foo: 1}}]},
+						},
+					},
+					true
+				)
+			)
+			expect(await eSDB.store.count.get('count')).toEqual({
+				id: 'count',
+				total: 1,
+				byType: {foo: 1},
+			})
+			expect(await eSDB.getVersion()).toBe(50)
+		})
+	})
+
+	test('dispatch', async () => {
+		return withESDB(async eSDB => {
+			const event1P = eSDB.dispatch('whattup', 'indeed', 42)
+			const event2P = eSDB.dispatch('dude', {woah: true}, 55)
+			expect(await event2P).toEqual({
+				v: 2,
+				type: 'dude',
+				ts: 55,
+				data: {woah: true},
+				result: {
+					count: {
+						set: [{id: 'count', total: 2, byType: {whattup: 1, dude: 1}}],
 					},
 				},
-				true
-			)
-		)
-		expect(await eSDB.store.count.get('count')).toEqual({
-			id: 'count',
-			total: 1,
-			byType: {foo: 1},
-		})
-		expect(await eSDB.getVersion()).toBe(50)
-	})
-})
-
-test('dispatch', async () => {
-	return withESDB(async eSDB => {
-		const event1P = eSDB.dispatch('whattup', 'indeed', 42)
-		const event2P = eSDB.dispatch('dude', {woah: true}, 55)
-		expect(await event2P).toEqual({
-			v: 2,
-			type: 'dude',
-			ts: 55,
-			data: {woah: true},
-			result: {
-				count: {
-					set: [{id: 'count', total: 2, byType: {whattup: 1, dude: 1}}],
-				},
-			},
-		})
-		expect(await event1P).toEqual({
-			v: 1,
-			type: 'whattup',
-			ts: 42,
-			data: 'indeed',
-			result: {
-				count: {set: [{id: 'count', total: 1, byType: {whattup: 1}}]},
-			},
-		})
-	})
-})
-
-test('derivers', async () => {
-	return withESDB(async eSDB => {
-		await eSDB.dispatch('bar')
-		expect(await eSDB.store.deriver.searchOne()).toEqual({
-			desc: 'Total: 1, seen types: bar',
-			id: 'descCount',
-		})
-	})
-})
-
-test('preprocessors', async () => {
-	return withESDB(
-		async eSDB => {
-			await expect(
-				eSDB._preprocessor({}, {type: 'pre type'})
-			).resolves.toHaveProperty(
-				'error._preprocess_meep',
-				expect.stringContaining('type')
-			)
-			await expect(
-				eSDB._preprocessor({}, {type: 'pre version'})
-			).resolves.toHaveProperty(
-				'error._preprocess_meep',
-				expect.stringContaining('version')
-			)
-			await expect(
-				eSDB._preprocessor({}, {type: 'bad event'})
-			).resolves.toHaveProperty(
-				'error._preprocess_meep',
-				expect.stringContaining('Yeah, no.')
-			)
-			await eSDB.dispatch('create_thing', {foo: 2})
-			expect(await eSDB.store.meep.searchOne()).toEqual({
-				id: '5',
-				foo: 2,
 			})
-		},
-		{
+			expect(await event1P).toEqual({
+				v: 1,
+				type: 'whattup',
+				ts: 42,
+				data: 'indeed',
+				result: {
+					count: {set: [{id: 'count', total: 1, byType: {whattup: 1}}]},
+				},
+			})
+		})
+	})
+
+	test('derivers', async () => {
+		return withESDB(async eSDB => {
+			await eSDB.dispatch('bar')
+			expect(await eSDB.store.deriver.searchOne()).toEqual({
+				desc: 'Total: 1, seen types: bar',
+				id: 'descCount',
+			})
+		})
+	})
+
+	test('preprocessors', async () => {
+		const models = {
 			meep: {
 				preprocessor: async ({event, model, store, dispatch, cache}) => {
 					if (typeof cache !== 'object')
@@ -122,60 +97,85 @@ test('preprocessors', async () => {
 				},
 			},
 		}
-	)
-})
-
-test('reducer, deriver data immutable', async () => {
-	return withESDB(
-		async eSDB => {
-			eSDB.__BE_QUIET = true
-			await expect(eSDB.dispatch('reduce', {})).rejects.toHaveProperty(
-				'error._reduce_meep'
+		return withESDB(models, async eSDB => {
+			await expect(
+				eSDB._preprocessor({}, {type: 'pre type'})
+			).resolves.toHaveProperty(
+				'error._preprocess_meep',
+				expect.stringContaining('type')
 			)
-			await eSDB.rwDb.userVersion((await eSDB.rwDb.userVersion()) + 1)
-			await expect(eSDB.dispatch('derive', {})).rejects.toHaveProperty(
-				'error._apply_derive'
+			await expect(
+				eSDB._preprocessor({}, {type: 'pre version'})
+			).resolves.toHaveProperty(
+				'error._preprocess_meep',
+				expect.stringContaining('version')
 			)
-		},
-		{
-			meep: {
-				reducer: ({event}) => {
-					if (event.type === 'reduce') event.data.foo = 'bar'
-				},
-				deriver: ({event}) => {
-					if (event.type === 'derive') event.data.foo = 'bar'
-				},
-			},
-		}
-	)
-})
-
-test('preprocessor/reducer for ESModel', async () =>
-	withESDB(
-		async eSDB => {
-			await eSDB.dispatch('set_thing', {foo: 2})
+			await expect(
+				eSDB._preprocessor({}, {type: 'bad event'})
+			).resolves.toHaveProperty(
+				'error._preprocess_meep',
+				expect.stringContaining('Yeah, no.')
+			)
+			await eSDB.dispatch('create_thing', {foo: 2})
 			expect(await eSDB.store.meep.searchOne()).toEqual({
-				id: 1,
+				id: '5',
 				foo: 2,
-				ok: true,
 			})
-			await eSDB.rwStore.meep.set({id: 2})
-			const event = await eSDB.queue.get(2)
-			expect(event.data).toEqual([1, 2, {id: 2}])
-			expect(event.result).toEqual({meep: {ins: [{id: 2}]}})
-		},
-		{
-			meep: {
-				columns: {id: {type: 'INTEGER'}},
-				preprocessor: async ({event}) => {
-					if (event.data && event.data.foo) event.data.ok = true
-				},
-				reducer: ({event}) => {
-					if (event.type === 'set_thing') {
-						return {set: [event.data]}
-					}
-					return false
+		})
+	})
+
+	test('reducer, deriver data immutable', async () => {
+		return withESDB(
+			{
+				meep: {
+					reducer: ({event}) => {
+						if (event.type === 'reduce') event.data.foo = 'bar'
+					},
+					deriver: ({event}) => {
+						if (event.type === 'derive') event.data.foo = 'bar'
+					},
 				},
 			},
-		}
-	))
+			async eSDB => {
+				eSDB.__BE_QUIET = true
+				await expect(eSDB.dispatch('reduce', {})).rejects.toHaveProperty(
+					'error._reduce_meep'
+				)
+				await eSDB.rwDb.userVersion((await eSDB.rwDb.userVersion()) + 1)
+				await expect(eSDB.dispatch('derive', {})).rejects.toHaveProperty(
+					'error._apply_derive'
+				)
+			}
+		)
+	})
+
+	test('preprocessor/reducer for ESModel', async () =>
+		withESDB(
+			{
+				meep: {
+					columns: {id: {type: 'INTEGER'}},
+					preprocessor: async ({event}) => {
+						if (event.data && event.data.foo) event.data.ok = true
+					},
+					reducer: ({event}) => {
+						if (event.type === 'set_thing') {
+							return {set: [event.data]}
+						}
+						return false
+					},
+				},
+			},
+			async eSDB => {
+				await eSDB.dispatch('set_thing', {foo: 2})
+				expect(await eSDB.store.meep.searchOne()).toEqual({
+					id: 1,
+					foo: 2,
+					ok: true,
+				})
+				await eSDB.rwStore.meep.set({id: 2})
+				const event = await eSDB.queue.get(2)
+				expect(event.data).toEqual([1, 2, {id: 2}])
+				expect(event.result).toEqual({meep: {ins: [{id: 2}]}})
+			}
+		))
+})

--- a/src/EventSourcingDB/ESDB-subevents.test.js
+++ b/src/EventSourcingDB/ESDB-subevents.test.js
@@ -1,112 +1,114 @@
 // @ts-check
 import {withESDB} from '../lib/_test-helpers'
 
-test('work', async () => {
-	const models = {
-		foo: {
-			preprocessor: ({event, addEvent, isMainEvent}) => {
-				expect(isMainEvent).not.toBeUndefined()
-				if (event.type === 'hi' || event.type === 'pre')
-					addEvent('pre-' + event.type)
+describe('subevents', () => {
+	test('work', async () => {
+		const models = {
+			foo: {
+				preprocessor: ({event, addEvent, isMainEvent}) => {
+					expect(isMainEvent).not.toBeUndefined()
+					if (event.type === 'hi' || event.type === 'pre')
+						addEvent('pre-' + event.type)
+				},
+				reducer: ({event, addEvent, isMainEvent}) => {
+					expect(isMainEvent).not.toBeUndefined()
+					let events
+					if (event.type === 'hi' || event.type === 'red') {
+						addEvent('red-' + event.type)
+						events = [{type: 'red-out-' + event.type}]
+					}
+					return {set: [{id: event.type}], events}
+				},
+				deriver: ({event, addEvent, isMainEvent}) => {
+					expect(isMainEvent).not.toBeUndefined()
+					if (event.type === 'hi' || event.type === 'der')
+						addEvent('der-' + event.type)
+				},
 			},
-			reducer: ({event, addEvent, isMainEvent}) => {
-				expect(isMainEvent).not.toBeUndefined()
-				let events
-				if (event.type === 'hi' || event.type === 'red') {
-					addEvent('red-' + event.type)
-					events = [{type: 'red-out-' + event.type}]
-				}
-				return {set: [{id: event.type}], events}
-			},
-			deriver: ({event, addEvent, isMainEvent}) => {
-				expect(isMainEvent).not.toBeUndefined()
-				if (event.type === 'hi' || event.type === 'der')
-					addEvent('der-' + event.type)
-			},
-		},
-	}
-	return withESDB(async eSDB => {
-		const checker = async id =>
-			// this way we see the desired value in the output
-			expect((await eSDB.store.foo.get(id)) || false).toHaveProperty('id', id)
-		const event = await eSDB.dispatch('hi')
-		expect(event.events).toHaveLength(4)
-		await checker('pre-hi')
-		await checker('red-hi')
-		await checker('red-out-hi')
-		await checker('der-hi')
-		expect((await eSDB.dispatch('pre')).events).toHaveLength(1)
-		await checker('pre-pre')
-		await eSDB.dispatch('red')
-		await checker('red-red')
-		await checker('red-out-red')
-		await eSDB.dispatch('der')
-		await checker('der-der')
-	}, models)
-})
+		}
+		return withESDB(models, async eSDB => {
+			const checker = async id =>
+				// this way we see the desired value in the output
+				expect((await eSDB.store.foo.get(id)) || false).toHaveProperty('id', id)
+			const event = await eSDB.dispatch('hi')
+			expect(event.events).toHaveLength(4)
+			await checker('pre-hi')
+			await checker('red-hi')
+			await checker('red-out-hi')
+			await checker('der-hi')
+			expect((await eSDB.dispatch('pre')).events).toHaveLength(1)
+			await checker('pre-pre')
+			await eSDB.dispatch('red')
+			await checker('red-red')
+			await checker('red-out-red')
+			await eSDB.dispatch('der')
+			await checker('der-der')
+		})
+	})
 
-test('depth first order', () => {
-	const models = {
-		foo: {
-			reducer: ({event, addEvent}) => {
-				if (event.type === 'hi') return {set: [{id: 'hi', all: ''}]}
-				if (event.type === '3') addEvent('4')
+	test('depth first order', () => {
+		const models = {
+			foo: {
+				reducer: ({event, addEvent}) => {
+					if (event.type === 'hi') return {set: [{id: 'hi', all: ''}]}
+					if (event.type === '3') addEvent('4')
+				},
+				deriver: async ({model, event, addEvent}) => {
+					if (event.type === 'hi') {
+						addEvent('1')
+						addEvent('3')
+					}
+					if (event.type === '1') addEvent('2')
+					if (event.type === '3') addEvent('5')
+					const t = await model.get('hi')
+					return model.set({id: 'hi', all: t.all + event.type})
+				},
 			},
-			deriver: async ({model, event, addEvent}) => {
-				if (event.type === 'hi') {
-					addEvent('1')
-					addEvent('3')
-				}
-				if (event.type === '1') addEvent('2')
-				if (event.type === '3') addEvent('5')
-				const t = await model.get('hi')
-				return model.set({id: 'hi', all: t.all + event.type})
-			},
-		},
-	}
-	return withESDB(async eSDB => {
-		const spy = jest.fn(event => event.type)
-		eSDB.on('result', spy)
-		const event = await eSDB.dispatch('hi')
-		expect(spy).toHaveBeenCalledTimes(1)
-		expect(event.events).toHaveLength(2)
-		expect(await eSDB.store.foo.get('hi')).toHaveProperty('all', 'hi12345')
-	}, models)
-})
+		}
+		return withESDB(models, async eSDB => {
+			const spy = jest.fn(event => event.type)
+			eSDB.on('result', spy)
+			const event = await eSDB.dispatch('hi')
+			expect(spy).toHaveBeenCalledTimes(1)
+			expect(event.events).toHaveLength(2)
+			expect(await eSDB.store.foo.get('hi')).toHaveProperty('all', 'hi12345')
+		})
+	})
 
-test('no infinite recursion', () => {
-	const models = {
-		foo: {
-			deriver: async ({event, addEvent}) => {
-				if (event.type === 'hi') addEvent('hi')
+	test('no infinite recursion', () => {
+		const models = {
+			foo: {
+				deriver: async ({event, addEvent}) => {
+					if (event.type === 'hi') addEvent('hi')
+				},
 			},
-		},
-	}
-	return withESDB(async eSDB => {
-		eSDB.__BE_QUIET = true
-		const doNotCall = jest.fn()
-		const event = await eSDB.dispatch('hi').then(doNotCall, e => e)
-		expect(doNotCall).toHaveBeenCalledTimes(0)
-		expect(event).toHaveProperty(
-			'error._handle',
-			expect.stringMatching(/(\.hi)+:.*deep/)
-		)
-	}, models)
-})
+		}
+		return withESDB(models, async eSDB => {
+			eSDB.__BE_QUIET = true
+			const doNotCall = jest.fn()
+			const event = await eSDB.dispatch('hi').then(doNotCall, e => e)
+			expect(doNotCall).toHaveBeenCalledTimes(0)
+			expect(event).toHaveProperty(
+				'error._handle',
+				expect.stringMatching(/(\.hi)+:.*deep/)
+			)
+		})
+	})
 
-test('replay clears subevents', () => {
-	const models = {
-		foo: {
-			deriver: async ({event, addEvent}) => {
-				if (event.type === 'hi') addEvent('ho')
+	test('replay clears subevents', () => {
+		const models = {
+			foo: {
+				deriver: async ({event, addEvent}) => {
+					if (event.type === 'hi') addEvent('ho')
+				},
 			},
-		},
-	}
-	return withESDB(async eSDB => {
-		await eSDB.queue.set({v: 5, type: 'hi', events: [{type: 'deleteme'}]})
-		const event = await eSDB.handledVersion(5)
-		expect(event).toHaveProperty('events', [
-			expect.objectContaining({type: 'ho'}),
-		])
-	}, models)
+		}
+		return withESDB(models, async eSDB => {
+			await eSDB.queue.set({v: 5, type: 'hi', events: [{type: 'deleteme'}]})
+			const event = await eSDB.handledVersion(5)
+			expect(event).toHaveProperty('events', [
+				expect.objectContaining({type: 'ho'}),
+			])
+		})
+	})
 })

--- a/src/EventSourcingDB/ESDB-subevents.test.js
+++ b/src/EventSourcingDB/ESDB-subevents.test.js
@@ -4,24 +4,24 @@ import {withESDB} from '../lib/_test-helpers'
 test('work', async () => {
 	const models = {
 		foo: {
-			preprocessor: ({event, dispatch, isMainEvent}) => {
+			preprocessor: ({event, addEvent, isMainEvent}) => {
 				expect(isMainEvent).not.toBeUndefined()
 				if (event.type === 'hi' || event.type === 'pre')
-					dispatch('pre-' + event.type)
+					addEvent('pre-' + event.type)
 			},
-			reducer: ({event, dispatch, isMainEvent}) => {
+			reducer: ({event, addEvent, isMainEvent}) => {
 				expect(isMainEvent).not.toBeUndefined()
 				let events
 				if (event.type === 'hi' || event.type === 'red') {
-					dispatch('red-' + event.type)
+					addEvent('red-' + event.type)
 					events = [{type: 'red-out-' + event.type}]
 				}
 				return {set: [{id: event.type}], events}
 			},
-			deriver: ({event, dispatch, isMainEvent}) => {
+			deriver: ({event, addEvent, isMainEvent}) => {
 				expect(isMainEvent).not.toBeUndefined()
 				if (event.type === 'hi' || event.type === 'der')
-					dispatch('der-' + event.type)
+					addEvent('der-' + event.type)
 			},
 		},
 	}
@@ -48,17 +48,17 @@ test('work', async () => {
 test('depth first order', () => {
 	const models = {
 		foo: {
-			reducer: ({event, dispatch}) => {
+			reducer: ({event, addEvent}) => {
 				if (event.type === 'hi') return {set: [{id: 'hi', all: ''}]}
-				if (event.type === '3') dispatch('4')
+				if (event.type === '3') addEvent('4')
 			},
-			deriver: async ({model, event, dispatch}) => {
+			deriver: async ({model, event, addEvent}) => {
 				if (event.type === 'hi') {
-					dispatch('1')
-					dispatch('3')
+					addEvent('1')
+					addEvent('3')
 				}
-				if (event.type === '1') dispatch('2')
-				if (event.type === '3') dispatch('5')
+				if (event.type === '1') addEvent('2')
+				if (event.type === '3') addEvent('5')
 				const t = await model.get('hi')
 				return model.set({id: 'hi', all: t.all + event.type})
 			},
@@ -77,8 +77,8 @@ test('depth first order', () => {
 test('no infinite recursion', () => {
 	const models = {
 		foo: {
-			deriver: async ({event, dispatch}) => {
-				if (event.type === 'hi') dispatch('hi')
+			deriver: async ({event, addEvent}) => {
+				if (event.type === 'hi') addEvent('hi')
 			},
 		},
 	}
@@ -97,8 +97,8 @@ test('no infinite recursion', () => {
 test('replay clears subevents', () => {
 	const models = {
 		foo: {
-			deriver: async ({event, dispatch}) => {
-				if (event.type === 'hi') dispatch('ho')
+			deriver: async ({event, addEvent}) => {
+				if (event.type === 'hi') addEvent('ho')
 			},
 		},
 	}

--- a/src/EventSourcingDB/ESModel.js
+++ b/src/EventSourcingDB/ESModel.js
@@ -132,6 +132,67 @@ class ESModel extends JsonModel {
 		this.writable = state
 	}
 
+	event = {
+		/**
+		 * Create an event that will insert or replace the given object into the
+		 * database.
+		 *
+		 * @param {Object}  obj           - the object to store. If there is no `id`
+		 *                                value (or whatever the `id` column is
+		 *                                named), one is assigned automatically.
+		 * @param {boolean} [insertOnly]  - don't allow replacing existing objects.
+		 * @param {*}       [meta]        - extra metadata to store in the event but
+		 *                                not in the object.
+		 * @returns {[string, Object?]} - args to pass to addEvent/dispatch.
+		 */
+		set: (obj, insertOnly, meta) => {
+			const data = [insertOnly ? ESModel.INSERT : ESModel.SET, null, obj]
+			if (meta) data[3] = meta
+			return {type: this.TYPE, data}
+		},
+		/**
+		 * Create an event that will update an existing object.
+		 *
+		 * @param {Object}  obj       - the data to store.
+		 * @param {boolean} [upsert]  - if `true`, allow inserting if the object
+		 *                            doesn't exist.
+		 * @param {*}       [meta]    - extra metadata to store in the event at
+		 *                            `data[3]` but not in the object.
+		 * @returns {[string, Object?]} - args to pass to addEvent/dispatch.
+		 */
+		update: (obj, upsert, meta) => {
+			const id = obj[this.idCol]
+			if (id == null && !upsert) throw new TypeError('No ID specified')
+
+			const data = [
+				upsert ? ESModel.SAVE : ESModel.UPDATE,
+				null,
+				undefToNull(obj),
+			]
+			if (meta) data.push(meta)
+
+			return {type: this.TYPE, data}
+		},
+		/**
+		 * Create an event that will emove an object.
+		 *
+		 * @param {Object | string | integer} idOrObj
+		 * - the id or the object itself.
+		 * @param {*} meta
+		 * - metadata, attached to the event only, at `data[3]`
+		 * @returns {[string, Object?]} - args to pass to addEvent/dispatch.
+		 */
+		remove: (idOrObj, meta) => {
+			const id = typeof idOrObj === 'object' ? idOrObj[this.idCol] : idOrObj
+			if (id == null) throw new TypeError('No ID specified')
+
+			const data = [ESModel.REMOVE, id]
+			if (meta) data[3] = meta
+
+			return {type: this.TYPE, data}
+		},
+	}
+
 	/**
 	 * Insert or replace the given object into the database.
 	 *
@@ -155,10 +216,9 @@ class ESModel extends JsonModel {
 			return super.set(obj, insertOnly, noReturn)
 		}
 
-		const d = [insertOnly ? ESModel.INSERT : ESModel.SET, null, obj]
-		if (meta) d[3] = meta
-
-		const {data, result} = await this.dispatch(this.TYPE, d)
+		const {data, result} = await this.dispatch(
+			this.event.set(obj, insertOnly, meta)
+		)
 		const id = data[1]
 
 		const r = result[this.name]
@@ -182,22 +242,19 @@ class ESModel extends JsonModel {
 	 * @returns {Promise<Object>} - if `noReturn` is false, the stored object is
 	 *                            fetched from the DB.
 	 */
-	async update(o, upsert, noReturn, meta) {
+	async update(obj, upsert, noReturn, meta) {
 		if (DEV && noReturn != null && typeof noReturn !== 'boolean')
 			throw new Error(`${this.name}: meta argument is now in fourth position`)
 
-		if (this.writable) return super.update(o, upsert, noReturn)
+		if (this.writable) return super.update(obj, upsert, noReturn)
 
 		if (DEV && noReturn != null && typeof noReturn !== 'boolean')
 			throw new Error(`${this.name}: meta argument is now in fourth position`)
-		let id = o[this.idCol]
-		if (id == null && !upsert) throw new TypeError('No ID specified')
 
-		const d = [upsert ? ESModel.SAVE : ESModel.UPDATE, null, undefToNull(o)]
-		if (meta) d.push(meta)
-
-		const {data, result} = await this.dispatch(this.TYPE, d)
-		id = data[1]
+		const {data, result} = await this.dispatch(
+			this.event.update(obj, upsert, meta)
+		)
+		const id = data[1]
 
 		const r = result[this.name]
 		if (r && r.esFail) throw new Error(`${this.name}.update ${id}: ${r.esFail}`)
@@ -223,13 +280,8 @@ class ESModel extends JsonModel {
 	 */
 	async remove(idOrObj, meta) {
 		if (this.writable) return super.remove(idOrObj)
-		const id = typeof idOrObj === 'object' ? idOrObj[this.idCol] : idOrObj
-		if (id == null) throw new TypeError('No ID specified')
 
-		const d = [ESModel.REMOVE, id]
-		if (meta) d[3] = meta
-
-		await this.dispatch(this.TYPE, d)
+		await this.dispatch(this.event.remove(idOrObj, meta))
 		return true
 	}
 
@@ -293,8 +345,9 @@ class ESModel extends JsonModel {
 	 * Calculates the desired change ESModel will only emit `rm`, `ins`, `upd` and
 	 * `esFail`
 	 *
-	 * @param {Object} model  - the model.
-	 * @param {Event}  event  - the event.
+	 * @param {Object}  params
+	 * @param {ESModel} params.model  - the model.
+	 * @param {Event}   params.event  - the event.
 	 * @returns {Promise<Object>} - the result object in the format JsonModel
 	 *                            likes.
 	 */

--- a/src/EventSourcingDB/ESModel.test.js
+++ b/src/EventSourcingDB/ESModel.test.js
@@ -33,469 +33,433 @@ class ESModelIntId extends ESModel {
 
 const sampleObject = {id: 'asd', meep: 'moop', top: 'kek'}
 
-test('undefToNull', () => {
-	const obj = {
-		a: 'b',
-		c: 4,
-		d: new Date('2007-01-01'),
-		nested: {
-			stuff: 'test',
-			asd: undefined,
-			dsa: null,
-		},
-		array: [
-			'two plus two is',
-			undefined,
-			{minus: 1, thats: '?'},
-			null,
-			'quick maths',
-		],
-		zxc: null,
-		cxz: undefined,
-	}
-	expect(undefToNull(obj)).toEqual({
-		...obj,
-		nested: {...obj.nested, asd: null},
-		array: [
-			'two plus two is',
-			null,
-			{minus: 1, thats: '?'},
-			null,
-			'quick maths',
-		],
-		cxz: null,
+describe('undefToNull', () => {
+	test('works', () => {
+		const obj = {
+			a: 'b',
+			c: 4,
+			d: new Date('2007-01-01'),
+			nested: {
+				stuff: 'test',
+				asd: undefined,
+				dsa: null,
+			},
+			array: [
+				'two plus two is',
+				undefined,
+				{minus: 1, thats: '?'},
+				null,
+				'quick maths',
+			],
+			zxc: null,
+			cxz: undefined,
+		}
+		expect(undefToNull(obj)).toEqual({
+			...obj,
+			nested: {...obj.nested, asd: null},
+			array: [
+				'two plus two is',
+				null,
+				{minus: 1, thats: '?'},
+				null,
+				'quick maths',
+			],
+			cxz: null,
+		})
 	})
 })
 
-test('create', () =>
-	withESDB(
-		async eSDB => {
-			const result = await eSDB.store.test.all()
-			expect(result).toEqual([])
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('getId standard settings', () =>
-	withESDB(
-		async eSDB => {
+describe('getId', () => {
+	test('standard settings', () =>
+		withESDB({test: {Model: ESModel}}, async eSDB => {
 			expect(await getId(eSDB.store.test, {top: 'kek'})).toBeTruthy()
-		},
-		{test: {Model: ESModel}}
-	))
+		}))
 
-test('getId custom idCol', () =>
-	withESDB(
-		async eSDB => {
+	test('custom idCol', () =>
+		withESDB({test: {Model: ESModelCustomId}}, async eSDB => {
 			expect(await getId(eSDB.store.test, {top: 'kek'})).toBeTruthy()
-		},
-		{test: {Model: ESModelCustomId}}
-	))
+		}))
 
-test('getId integer idCol', () =>
-	withESDB(
-		async eSDB => {
+	test('integer idCol', () =>
+		withESDB({test: {Model: ESModelIntId}}, async eSDB => {
 			expect(await getId(eSDB.store.test, {top: 'kek'})).toBe(1)
 			expect(await getId(eSDB.store.test, {top: 'kek'})).toBe(2)
 			await eSDB.store.test.set({myId: 7, asd: 'dsa'})
 			expect(await getId(eSDB.store.test, {moop: 'meep'})).toBe(8)
-		},
-		{
-			test: {Model: ESModelIntId},
-		}
-	))
-
-test('set w/ id', () =>
-	withESDB(
-		async eSDB => {
-			expect(await eSDB.store.test.set(sampleObject)).toEqual(sampleObject)
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('set w/o id', () =>
-	withESDB(
-		async eSDB => {
-			const newObject = await eSDB.store.test.set({
-				...sampleObject,
-				id: undefined,
-			})
-			expect(await eSDB.store.test.get(newObject.id)).toEqual(newObject)
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('set w/o id int', () =>
-	withESDB(
-		async eSDB => {
-			const sampleWithoutId = {
-				...sampleObject,
-				id: undefined,
-			}
-			await Promise.all([
-				eSDB.store.test.set(sampleWithoutId),
-				eSDB.store.test.set(sampleWithoutId),
-				eSDB.store.test.set(sampleWithoutId),
-			])
-			expect(await getId(eSDB.store.test, {top: 'kek'})).toEqual(4)
-			expect(await eSDB.store.test.count()).toEqual(3)
-		},
-		{test: {Model: ESModelIntId}}
-	))
-
-test('set w/ calc value', () =>
-	withESDB(
-		async eSDB => {
-			const sampleWithoutId = {
-				...sampleObject,
-				id: undefined,
-			}
-			await expect(
-				eSDB.store.test.set(sampleWithoutId)
-			).resolves.toHaveProperty('calc', 1)
-			await expect(
-				eSDB.store.test.update({myId: 1, calc: 5})
-			).resolves.toHaveProperty('calc', 1)
-		},
-		{test: {Model: ESModelIntId}}
-	))
-
-test('set insertOnly', () =>
-	withESDB(
-		async eSDB => {
-			await expect(
-				Promise.all([
-					eSDB.store.test.set(sampleObject, true),
-					eSDB.store.test.set(sampleObject, true),
-				])
-			).rejects.toThrow('EEXIST')
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('update', () =>
-	withESDB(
-		async eSDB => {
-			await eSDB.store.test.set(sampleObject)
-			const newObject = {
-				id: sampleObject.id,
-				top: 'bottom',
-				new: 'prop',
-			}
-			await eSDB.store.test.update(newObject)
-			const items = await eSDB.store.test.all()
-			expect(items).toHaveLength(1)
-			expect(items[0]).toEqual({...sampleObject, ...newObject})
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('update w/o id', () =>
-	withESDB(
-		async eSDB => {
-			await expect(eSDB.store.test.update({top: 'kek'})).rejects.toThrow(
-				'No ID specified'
-			)
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('update w/ undefined values', () =>
-	withESDB(
-		async eSDB => {
-			await eSDB.store.test.set(sampleObject)
-			expect(
-				await eSDB.store.test.update({id: sampleObject.id, top: undefined})
-			).toEqual({...sampleObject, top: undefined})
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('update non-existent object', () =>
-	withESDB(
-		async eSDB => {
-			await expect(eSDB.store.test.update(sampleObject)).rejects.toThrow(
-				'ENOENT'
-			)
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('update upsert', () =>
-	withESDB(
-		async eSDB => {
-			expect(await eSDB.store.test.update(sampleObject, true)).toEqual(
-				sampleObject
-			)
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('update upsert w/o id', () =>
-	withESDB(
-		async eSDB => {
-			expect(await eSDB.store.test.update({top: 'kek'}, true)).toEqual({
-				myId: 1,
-				top: 'kek',
-				calc: 1,
-			})
-		},
-		{test: {Model: ESModelIntId}}
-	))
-
-test('remove by id', () =>
-	withESDB(
-		async eSDB => {
-			await eSDB.store.test.set(sampleObject)
-			expect(await eSDB.store.test.remove(sampleObject.id)).toEqual(true)
-			expect(await eSDB.store.test.all()).toEqual([])
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('remove by object', () =>
-	withESDB(
-		async eSDB => {
-			await eSDB.store.test.set(sampleObject)
-			expect(await eSDB.store.test.remove(sampleObject)).toEqual(true)
-			expect(await eSDB.store.test.all()).toEqual([])
-		},
-		{test: {Model: ESModel}}
-	))
-
-test('remove by object without id', () =>
-	withESDB(
-		async eSDB => {
-			await eSDB.store.test.set(sampleObject)
-			await expect(
-				eSDB.store.test.remove({...sampleObject, id: undefined})
-			).rejects.toThrow()
-		},
-		{test: {Model: ESModel}}
-	))
-
-class Foo {
-	getF() {
-		return this.f
-	}
-}
-
-test('ItemClass set', () =>
-	withESDB(
-		async eSDB => {
-			const {m} = eSDB.store
-			const setted = await m.set({id: 4, f: 'meep'})
-			expect(setted instanceof Foo).toBe(true)
-			expect(setted.getF()).toBe('meep')
-		},
-		{
-			m: {
-				Model: class extends ESModel {
-					constructor(o) {
-						super({...o, ItemClass: Foo})
-					}
-				},
-			},
-		}
-	))
-
-test('preprocessor', () => {
-	let ok
-	return withESDB(
-		async eSDB => {
-			const {m} = eSDB.store
-			await m.set({hi: 'a', meep: 'moop'})
-			expect(ok).toBe(true)
-		},
-		{
-			m: {
-				idCol: 'hi',
-				reducer: args => {
-					if (!args.model) return false
-					if (args.event.type === args.model.TYPE && args.event.data[1] === 'a')
-						ok = true
-					return ESModel.reducer(args)
-				},
-			},
-		}
-	)
+		}))
 })
 
-test('init', () =>
-	withESDB(
-		async eSDB => {
-			await eSDB.waitForQueue()
-			const {m} = eSDB.store
-			expect(await m.exists({id: 'yey'})).toBeTruthy()
-		},
-		{
-			m: {
-				init: true,
-				reducer: ({model, event}) =>
-					event.type === model.INIT ? {ins: [{id: 'yey'}]} : false,
-			},
-		}
-	))
+describe('ESModel', () => {
+	test('create', () =>
+		withESDB({test: {Model: ESModel}}, async eSDB => {
+			const result = await eSDB.store.test.all()
+			expect(result).toEqual([])
+		}))
 
-test('events', () =>
-	withESDB(
-		async (eSDB, queue) => {
-			const {m} = eSDB.store
-			await m.set({meep: 'moop'})
-			await m.update({id: 1, beep: 'boop'})
-			await m.set({meep: 'moop'}, true)
-			await m.update({id: 3, beep: 'boop'}, true)
-			await m.remove(3)
-			const events = await queue.all()
-			expect(
-				events.map(e => {
-					e.ts = 0
-					return e
-				})
-			).toMatchSnapshot()
-		},
-		{m: {columns: {id: {type: 'INTEGER'}}}}
-	))
-
-test('events updates', () =>
-	withESDB(
-		async (eSDB, queue) => {
-			const {m} = eSDB.store
-			expect(await m.set({meep: 'moop'})).toEqual({v: 1, meep: 'moop'})
-			expect(await m.set({v: 1, meep: 'moop'})).toEqual({
-				v: 1,
-				meep: 'moop',
-			})
-			expect(await m.set({v: 1, beep: 'boop', a: [null, 3]})).toEqual({
-				v: 1,
-				beep: 'boop',
-				a: [null, 3],
-			})
-			expect(await m.update({v: 1, beep: 'boop'})).toEqual({
-				v: 1,
-				beep: 'boop',
-				a: [null, 3],
-			})
-			expect(await m.update({v: 1, beep: 'foop', a: [null, 3]})).toEqual({
-				v: 1,
-				beep: 'foop',
-				a: [null, 3],
-			})
-			const events = await queue.all()
-			expect(
-				events.map(e => {
-					e.ts = 0
-					return e
-				})
-			).toMatchSnapshot()
-		},
-		{m: {idCol: 'v', columns: {v: {type: 'INTEGER'}}}}
-	))
-
-test('metadata in event', () =>
-	withESDB(
-		async (eSDB, queue) => {
-			const {m} = eSDB.store
-			await m.set({meep: 'moop'}, null, true, {meta: 1})
-			await m.update({id: 1, beep: 'boop'}, null, true, {meta: 2})
-			await m.set({meep: 'moop'}, true, true, {meta: 3})
-			await m.update({id: 3, beep: 'boop'}, true, true, 'hi')
-			await m.set({})
-			await m.remove(3, {meta: 4})
-			await m.remove(2)
-			const events = await queue.all()
-			expect(events[0].data).toHaveLength(4)
-			expect(events[4].data).toHaveLength(3)
-			expect(events[6].data).toHaveLength(2)
-			expect(events.map(e => e.data[3])).toEqual([
-				{meta: 1},
-				{meta: 2},
-				{meta: 3},
-				'hi',
-				undefined,
-				{meta: 4},
-				undefined,
-			])
-		},
-		{m: {columns: {id: {type: 'INTEGER'}}}}
-	))
-
-describe('getNextId', () => {
-	test('works', () =>
+	test('init', () =>
 		withESDB(
+			{
+				m: {
+					init: true,
+					reducer: ({model, event}) =>
+						event.type === model.INIT ? {ins: [{id: 'yey'}]} : false,
+				},
+			},
 			async eSDB => {
+				await eSDB.waitForQueue()
+				const {m} = eSDB.store
+				expect(await m.exists({id: 'yey'})).toBeTruthy()
+			}
+		))
+
+	describe('.set()', () => {
+		test('with id', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				expect(await eSDB.store.test.set(sampleObject)).toEqual(sampleObject)
+			}))
+
+		test('without id', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				const newObject = await eSDB.store.test.set({
+					...sampleObject,
+					id: undefined,
+				})
+				expect(await eSDB.store.test.get(newObject.id)).toEqual(newObject)
+			}))
+
+		test('without integer id', () =>
+			withESDB({test: {Model: ESModelIntId}}, async eSDB => {
+				const sampleWithoutId = {
+					...sampleObject,
+					id: undefined,
+				}
+				await Promise.all([
+					eSDB.store.test.set(sampleWithoutId),
+					eSDB.store.test.set(sampleWithoutId),
+					eSDB.store.test.set(sampleWithoutId),
+				])
+				expect(await getId(eSDB.store.test, {top: 'kek'})).toEqual(4)
+				expect(await eSDB.store.test.count()).toEqual(3)
+			}))
+
+		test('calculated value', () =>
+			withESDB({test: {Model: ESModelIntId}}, async eSDB => {
+				const sampleWithoutId = {
+					...sampleObject,
+					id: undefined,
+				}
+				await expect(
+					eSDB.store.test.set(sampleWithoutId)
+				).resolves.toHaveProperty('calc', 1)
+				await expect(
+					eSDB.store.test.update({myId: 1, calc: 5})
+				).resolves.toHaveProperty('calc', 1)
+			}))
+
+		test('insertOnly', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				await expect(
+					Promise.all([
+						eSDB.store.test.set(sampleObject, true),
+						eSDB.store.test.set(sampleObject, true),
+					])
+				).rejects.toThrow('EEXIST')
+			}))
+	})
+
+	describe('.update()', () => {
+		test('works', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				await eSDB.store.test.set(sampleObject)
+				const newObject = {
+					id: sampleObject.id,
+					top: 'bottom',
+					new: 'prop',
+				}
+				await eSDB.store.test.update(newObject)
+				const items = await eSDB.store.test.all()
+				expect(items).toHaveLength(1)
+				expect(items[0]).toEqual({...sampleObject, ...newObject})
+			}))
+
+		test('without id', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				await expect(eSDB.store.test.update({top: 'kek'})).rejects.toThrow(
+					'No ID specified'
+				)
+			}))
+
+		test('undefined values', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				await eSDB.store.test.set(sampleObject)
+				expect(
+					await eSDB.store.test.update({id: sampleObject.id, top: undefined})
+				).toEqual({...sampleObject, top: undefined})
+			}))
+
+		test('non-existent object', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				await expect(eSDB.store.test.update(sampleObject)).rejects.toThrow(
+					'ENOENT'
+				)
+			}))
+
+		test('upsert', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				expect(await eSDB.store.test.update(sampleObject, true)).toEqual(
+					sampleObject
+				)
+			}))
+
+		test('upsert without id', () =>
+			withESDB({test: {Model: ESModelIntId}}, async eSDB => {
+				expect(await eSDB.store.test.update({top: 'kek'}, true)).toEqual({
+					myId: 1,
+					top: 'kek',
+					calc: 1,
+				})
+			}))
+	})
+
+	describe('.remove()', () => {
+		test('remove by id', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				await eSDB.store.test.set(sampleObject)
+				expect(await eSDB.store.test.remove(sampleObject.id)).toEqual(true)
+				expect(await eSDB.store.test.all()).toEqual([])
+			}))
+
+		test('remove by object', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				await eSDB.store.test.set(sampleObject)
+				expect(await eSDB.store.test.remove(sampleObject)).toEqual(true)
+				expect(await eSDB.store.test.all()).toEqual([])
+			}))
+
+		test('remove by object without id', () =>
+			withESDB({test: {Model: ESModel}}, async eSDB => {
+				await eSDB.store.test.set(sampleObject)
+				await expect(
+					eSDB.store.test.remove({...sampleObject, id: undefined})
+				).rejects.toThrow()
+			}))
+	})
+
+	describe('preprocessor', () => {
+		test('works', () => {
+			let ok
+			return withESDB(
+				{
+					m: {
+						idCol: 'hi',
+						reducer: args => {
+							if (!args.model) return false
+							if (
+								args.event.type === args.model.TYPE &&
+								args.event.data[1] === 'a'
+							)
+								ok = true
+							return ESModel.reducer(args)
+						},
+					},
+				},
+				async eSDB => {
+					const {m} = eSDB.store
+					await m.set({hi: 'a', meep: 'moop'})
+					expect(ok).toBe(true)
+				}
+			)
+		})
+	})
+
+	describe('itemClass', () => {
+		class Foo {
+			getF() {
+				return this.f
+			}
+		}
+
+		test('set', () =>
+			withESDB(
+				{
+					m: {
+						Model: class extends ESModel {
+							constructor(o) {
+								super({...o, ItemClass: Foo})
+							}
+						},
+					},
+				},
+				async eSDB => {
+					const {m} = eSDB.store
+					const setted = await m.set({id: 4, f: 'meep'})
+					expect(setted instanceof Foo).toBe(true)
+					expect(setted.getF()).toBe('meep')
+				}
+			))
+	})
+
+	describe('.getNextId()', () => {
+		test('works', () =>
+			withESDB({m: {columns: {id: {type: 'INTEGER'}}}}, async eSDB => {
 				const {m} = eSDB.store
 				await expect(m.getNextId()).resolves.toBe(1)
 				await m.set({id: 1})
 				await expect(m.getNextId()).resolves.toBe(2)
 				await eSDB.dispatch(m.TYPE, [ESModel.INSERT, 5, {id: 5}])
 				await expect(m.getNextId()).resolves.toBe(6)
-			},
-			{m: {columns: {id: {type: 'INTEGER'}}}}
-		))
+			}))
 
-	test('concurrent', () =>
-		withESDB(
-			async eSDB => {
+		test('concurrent', () =>
+			withESDB({m: {columns: {id: {type: 'INTEGER'}}}}, async eSDB => {
 				const {m} = eSDB.store
 				expect(await Promise.all([m.getNextId(), m.getNextId()])).toEqual([
 					1, 2,
 				])
-			},
-			{m: {columns: {id: {type: 'INTEGER'}}}}
-		))
+			}))
 
-	test('run in subevent', () =>
-		withESDB(
-			async eSDB => {
-				await eSDB.store.test.set({name: 'id 1'})
-				await eSDB.store.test.set({name: 'id 2'})
-				await eSDB.store.test.set({name: 'id 3'})
-				await eSDB.store.test.set({name: 'id 4'})
-				await eSDB.store.test.set({name: 'id 5'})
-				await eSDB.store.test.update({id: 1, triggerSub: 'oh yiss'})
-
-				expect(await eSDB.store.test.get(6)).toHaveProperty('fromDeriver', true)
-				expect(await eSDB.store.test.get(7)).toHaveProperty(
-					'fromSubevent',
-					true
-				)
-			},
-			{
-				test: {
-					Model: class ESModelSubevents extends ESModel {
-						constructor(options) {
-							super({
-								...options,
-								columns: {
-									id: {
-										type: 'INTEGER',
+		test('run in subevent', () =>
+			withESDB(
+				{
+					test: {
+						Model: class ESModelSubevents extends ESModel {
+							constructor(options) {
+								super({
+									...options,
+									columns: {
+										id: {
+											type: 'INTEGER',
+										},
 									},
-								},
-							})
-						}
+								})
+							}
 
-						static async reducer(arg) {
-							const {event, dispatch, model} = arg
-							const result = (await super.reducer(arg)) || event.result || {}
-							if (event.type === 'SUBEVENT') {
-								return {
-									ins: [{id: await model.getNextId(), fromSubevent: true}],
+							static async reducer(arg) {
+								const {event, addEvent, model} = arg
+								const result = (await super.reducer(arg)) || event.result || {}
+								if (event.type === 'SUBEVENT') {
+									return {
+										ins: [{id: await model.getNextId(), fromSubevent: true}],
+									}
+								}
+								if (
+									result &&
+									result.upd &&
+									result.upd.some(e => e.triggerSub)
+								) {
+									addEvent('SUBEVENT')
+								}
+								return result
+							}
+
+							static async deriver({model, result}) {
+								if (
+									result &&
+									result.upd &&
+									result.upd.some(e => e.triggerSub)
+								) {
+									model.set({fromDeriver: true})
 								}
 							}
-							if (result && result.upd && result.upd.some(e => e.triggerSub)) {
-								dispatch('SUBEVENT')
-							}
-							return result
-						}
-
-						static async deriver({model, result}) {
-							if (result && result.upd && result.upd.some(e => e.triggerSub)) {
-								model.set({fromDeriver: true})
-							}
-						}
+						},
 					},
 				},
-			}
-		))
+				async eSDB => {
+					await eSDB.store.test.set({name: 'id 1'})
+					await eSDB.store.test.set({name: 'id 2'})
+					await eSDB.store.test.set({name: 'id 3'})
+					await eSDB.store.test.set({name: 'id 4'})
+					await eSDB.store.test.set({name: 'id 5'})
+					await eSDB.store.test.update({id: 1, triggerSub: 'oh yiss'})
+
+					expect(await eSDB.store.test.get(6)).toHaveProperty(
+						'fromDeriver',
+						true
+					)
+					expect(await eSDB.store.test.get(7)).toHaveProperty(
+						'fromSubevent',
+						true
+					)
+				}
+			))
+	})
+
+	describe('events', () => {
+		test('work', () =>
+			withESDB({m: {columns: {id: {type: 'INTEGER'}}}}, async (eSDB, queue) => {
+				const {m} = eSDB.store
+				await m.set({meep: 'moop'})
+				await m.update({id: 1, beep: 'boop'})
+				await m.set({meep: 'moop'}, true)
+				await m.update({id: 3, beep: 'boop'}, true)
+				await m.remove(3)
+				const events = await queue.all()
+				expect(
+					events.map(e => {
+						e.ts = 0
+						return e
+					})
+				).toMatchSnapshot()
+			}))
+
+		test('are updated', () =>
+			withESDB(
+				{m: {idCol: 'v', columns: {v: {type: 'INTEGER'}}}},
+				async (eSDB, queue) => {
+					const {m} = eSDB.store
+					expect(await m.set({meep: 'moop'})).toEqual({v: 1, meep: 'moop'})
+					expect(await m.set({v: 1, meep: 'moop'})).toEqual({
+						v: 1,
+						meep: 'moop',
+					})
+					expect(await m.set({v: 1, beep: 'boop', a: [null, 3]})).toEqual({
+						v: 1,
+						beep: 'boop',
+						a: [null, 3],
+					})
+					expect(await m.update({v: 1, beep: 'boop'})).toEqual({
+						v: 1,
+						beep: 'boop',
+						a: [null, 3],
+					})
+					expect(await m.update({v: 1, beep: 'foop', a: [null, 3]})).toEqual({
+						v: 1,
+						beep: 'foop',
+						a: [null, 3],
+					})
+					const events = await queue.all()
+					expect(
+						events.map(e => {
+							e.ts = 0
+							return e
+						})
+					).toMatchSnapshot()
+				}
+			))
+
+		test('hold metadata', () =>
+			withESDB({m: {columns: {id: {type: 'INTEGER'}}}}, async (eSDB, queue) => {
+				const {m} = eSDB.store
+				await m.set({meep: 'moop'}, null, true, {meta: 1})
+				await m.update({id: 1, beep: 'boop'}, null, true, {meta: 2})
+				await m.set({meep: 'moop'}, true, true, {meta: 3})
+				await m.update({id: 3, beep: 'boop'}, true, true, 'hi')
+				await m.set({})
+				await m.remove(3, {meta: 4})
+				await m.remove(2)
+				const events = await queue.all()
+				expect(events[0].data).toHaveLength(4)
+				expect(events[4].data).toHaveLength(3)
+				expect(events[6].data).toHaveLength(2)
+				expect(events.map(e => e.data[3])).toEqual([
+					{meta: 1},
+					{meta: 2},
+					{meta: 3},
+					'hi',
+					undefined,
+					{meta: 4},
+					undefined,
+				])
+			}))
+	})
 })

--- a/src/EventSourcingDB/ESModel.test.js
+++ b/src/EventSourcingDB/ESModel.test.js
@@ -461,5 +461,54 @@ describe('ESModel', () => {
 					undefined,
 				])
 			}))
+
+		describe('event creators', () => {
+			const m = new ESModel({
+				name: 'hi',
+				db: {registerMigrations: () => {}, on: () => {}},
+				emitter: {on: () => {}},
+			})
+			test.each([
+				[
+					'set',
+					[{foo: true}],
+					{type: 'es/hi', data: [ESModel.SET, null, {foo: true}]},
+				],
+				[
+					'set',
+					[{id: 'hi', bar: true}, true, {meta: 'hello'}],
+					{
+						type: 'es/hi',
+						data: [
+							ESModel.INSERT,
+							null,
+							{id: 'hi', bar: true},
+							{meta: 'hello'},
+						],
+					},
+				],
+				[
+					'update',
+					[{id: 7, foo: true, bar: undefined}],
+					{
+						type: 'es/hi',
+						data: [ESModel.UPDATE, null, {id: 7, foo: true, bar: null}],
+					},
+				],
+				[
+					'update', // with upsert
+					[{foo: true}, true],
+					{type: 'es/hi', data: [ESModel.SAVE, null, {foo: true}]},
+				],
+				[
+					'remove',
+					[{id: 'hi', f: 1}],
+					{type: 'es/hi', data: [ESModel.REMOVE, 'hi']},
+				],
+				['remove', [7], {type: 'es/hi', data: [ESModel.REMOVE, 7]}],
+			])('.event.%s%O => %O', (action, input, output) =>
+				expect(m.event[action](...input)).toEqual(output)
+			)
+		})
 	})
 })

--- a/src/EventSourcingDB/__snapshots__/ESModel.test.js.snap
+++ b/src/EventSourcingDB/__snapshots__/ESModel.test.js.snap
@@ -1,117 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`events 1`] = `
-Array [
-  Object {
-    "data": Array [
-      1,
-      1,
-      Object {
-        "meep": "moop",
-      },
-    ],
-    "result": Object {
-      "m": Object {
-        "ins": Array [
-          Object {
-            "id": 1,
-            "meep": "moop",
-          },
-        ],
-      },
-    },
-    "ts": 0,
-    "type": "es/m",
-    "v": 1,
-  },
-  Object {
-    "data": Array [
-      3,
-      1,
-      Object {
-        "beep": "boop",
-        "id": 1,
-      },
-    ],
-    "result": Object {
-      "m": Object {
-        "upd": Array [
-          Object {
-            "beep": "boop",
-            "id": 1,
-          },
-        ],
-      },
-    },
-    "ts": 0,
-    "type": "es/m",
-    "v": 2,
-  },
-  Object {
-    "data": Array [
-      2,
-      2,
-      Object {
-        "meep": "moop",
-      },
-    ],
-    "result": Object {
-      "m": Object {
-        "ins": Array [
-          Object {
-            "id": 2,
-            "meep": "moop",
-          },
-        ],
-      },
-    },
-    "ts": 0,
-    "type": "es/m",
-    "v": 3,
-  },
-  Object {
-    "data": Array [
-      4,
-      3,
-      Object {
-        "beep": "boop",
-        "id": 3,
-      },
-    ],
-    "result": Object {
-      "m": Object {
-        "ins": Array [
-          Object {
-            "beep": "boop",
-            "id": 3,
-          },
-        ],
-      },
-    },
-    "ts": 0,
-    "type": "es/m",
-    "v": 4,
-  },
-  Object {
-    "data": Array [
-      0,
-      3,
-    ],
-    "result": Object {
-      "m": Object {
-        "rm": Array [
-          3,
-        ],
-      },
-    },
-    "ts": 0,
-    "type": "es/m",
-    "v": 5,
-  },
-]
-`;
-
-exports[`events updates 1`] = `
+exports[`ESModel events are updated 1`] = `
 Array [
   Object {
     "data": Array [
@@ -215,6 +104,117 @@ Array [
             "beep": "foop",
             "v": 1,
           },
+        ],
+      },
+    },
+    "ts": 0,
+    "type": "es/m",
+    "v": 5,
+  },
+]
+`;
+
+exports[`ESModel events work 1`] = `
+Array [
+  Object {
+    "data": Array [
+      1,
+      1,
+      Object {
+        "meep": "moop",
+      },
+    ],
+    "result": Object {
+      "m": Object {
+        "ins": Array [
+          Object {
+            "id": 1,
+            "meep": "moop",
+          },
+        ],
+      },
+    },
+    "ts": 0,
+    "type": "es/m",
+    "v": 1,
+  },
+  Object {
+    "data": Array [
+      3,
+      1,
+      Object {
+        "beep": "boop",
+        "id": 1,
+      },
+    ],
+    "result": Object {
+      "m": Object {
+        "upd": Array [
+          Object {
+            "beep": "boop",
+            "id": 1,
+          },
+        ],
+      },
+    },
+    "ts": 0,
+    "type": "es/m",
+    "v": 2,
+  },
+  Object {
+    "data": Array [
+      2,
+      2,
+      Object {
+        "meep": "moop",
+      },
+    ],
+    "result": Object {
+      "m": Object {
+        "ins": Array [
+          Object {
+            "id": 2,
+            "meep": "moop",
+          },
+        ],
+      },
+    },
+    "ts": 0,
+    "type": "es/m",
+    "v": 3,
+  },
+  Object {
+    "data": Array [
+      4,
+      3,
+      Object {
+        "beep": "boop",
+        "id": 3,
+      },
+    ],
+    "result": Object {
+      "m": Object {
+        "ins": Array [
+          Object {
+            "beep": "boop",
+            "id": 3,
+          },
+        ],
+      },
+    },
+    "ts": 0,
+    "type": "es/m",
+    "v": 4,
+  },
+  Object {
+    "data": Array [
+      0,
+      3,
+    ],
+    "result": Object {
+      "m": Object {
+        "rm": Array [
+          3,
         ],
       },
     },

--- a/src/JsonModel/JM-create.test.js
+++ b/src/JsonModel/JM-create.test.js
@@ -125,6 +125,20 @@ test('get w/ other colName', async () => {
 	expect(await m.get(10, 'slug')).toEqual({id: 0, slug: 10})
 })
 
+test('get w/ where', async () => {
+	const m = getModel({
+		columns: {
+			name: {
+				real: true,
+				where: 'lower(name) = ?',
+				whereVal: v => [v.toLowerCase()],
+			},
+		},
+	})
+	await m.set({name: 'HI'})
+	expect(await m.get('Hi', 'name')).toHaveProperty('name', 'HI')
+})
+
 test('getAll', async () => {
 	const m = getModel({
 		columns: {

--- a/src/JsonModel/JM-migration.test.js
+++ b/src/JsonModel/JM-migration.test.js
@@ -103,3 +103,17 @@ test('column add', () =>
 		},
 		{unsafeCleanup: true, prefix: 'jm-coladd'}
 	))
+
+test('failed migration', async () => {
+	const m = getModel({
+		name: 'test',
+		migrations: {
+			fail: async ({model}) => {
+				await model.set({id: 'hi'})
+				throw new Error('oh no')
+			},
+		},
+	})
+	await expect(m.db.store.test.get('id')).rejects.toThrow('oh no')
+	expect(m.db.isOpen).toBe(false)
+})

--- a/types.d.ts
+++ b/types.d.ts
@@ -662,6 +662,17 @@ interface EventQueue<T extends ESEvent = ESEvent> extends JsonModel<T, 'v'> {
 	setKnownV(v: number): Promise<void>
 }
 
+type DispatchFn = (
+	type: string,
+	data?: any,
+	ts?: number
+) =>
+	| Promise<ESEvent>
+	| ((arg: {type: string; data?: any; ts?: number}) => Promise<ESEvent>)
+type AddEventFn = (
+	type: string,
+	data?: any
+) => void | ((arg: {type: string; data?: any}) => void)
 type ReduceResult = {[applyType: string]: any}
 type ReduxArgs<M extends InstanceType<ESDBModel>> = {
 	model: InstanceType<M>
@@ -684,8 +695,6 @@ type ESEvent = {
 	/** event processing result */
 	result?: Record<string, ReduceResult>
 }
-type DispatchFn = (type: string, data?: any, ts?: number) => Promise<ESEvent>
-type AddEventFn = (type: string, data?: any) => void
 
 type EMOptions<T, U extends string> = JMOptions<T, U> & {
 	/** the ESDB dispatch function */
@@ -861,7 +870,7 @@ interface EventSourcingDB extends EventEmitter {
 
 	stopPolling(): Promise<void>
 
-	dispatch(type: string, data?: any, ts?: number): Promise<ESEvent>
+	dispatch: DispatchFn
 
 	getVersion(): Promise<number>
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -107,6 +107,10 @@ interface SQLite extends EventEmitter {
 	 */
 	sql(): {quoteId: (id: string) => string} & SqlTag
 	/**
+	 * `true` if an sqlite connection was set up. Mostly useful for tests.
+	 */
+	isOpen: boolean
+	/**
 	 * Force opening the database instead of doing it lazily on first access.
 	 *
 	 * @returns - a promise for the DB being ready to use.
@@ -118,6 +122,17 @@ interface SQLite extends EventEmitter {
 	 * @returns - a promise for the DB being closed.
 	 */
 	close(): Promise<void>
+	/**
+	 * Runs the passed function once, either immediately if the connection is
+	 * already open, or when the database will be opened next.
+	 * Note that if the function runs immediately, its return value is returned.
+	 * If this is a Promise, it is the caller's responsibility to handle errors.
+	 * Otherwise, the function will be run once after onDidOpen, and errors will
+	 * cause the open to fail.
+	 *
+	 * @returns Either the function return value or undefined.
+	 */
+	runOnceOnOpen(fn: (db: SQLite) => void): void
 	/**
 	 * Return all rows for the given query.
 	 *


### PR DESCRIPTION
This adds the transact phase we discussed.

@Dzieni I didn't add the ESModel event creators yet, I want to allow `dispatch({type, data})` instead of `dispatch(type, data)` first, so that event creators don't need interpolation on dispatch.