### PR TITLE
eachFind: first draft

### DIFF
--- a/src/lib/settleAllFindFirst.js
+++ b/src/lib/settleAllFindFirst.js
@@ -1,0 +1,24 @@
+export /**
+ *	Execute all fn (asynchronously), if fn returns values, it returns the first result
+ *
+ * @param {[objects]} items
+ * @param {function} fn
+ * @returns {any} first positive result
+ */
+const settleAllFindFirst = async (items, fn) => {
+	let err
+	const results = await Promise.all(
+		items.map(async i => {
+			try {
+				const res = await fn(i)
+				if (res) return res
+			} catch (error) {
+				// last one wins
+				err = error
+			}
+		})
+	)
+	if (err) throw err
+	if (results?.filter(Boolean).length) return results[0]
+	return false
+}


### PR DESCRIPTION
I would like to shyly propose a new db search function `.eachFind`. It will works as `.each` until callback function `fn` returns the first positive result. Precisely, all `fn`'s grouped in particular `settleAll` will be executed, but it is still a progress in compare to `.each`'s full execution.