### PR TITLE
types: fix dispatchFn param type

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -770,9 +770,8 @@ type TransactFn<M extends ESDBModel = ESModel<{}>> = (
 	args: Omit<ReduxArgs<M>, 'addEvent'> & {dispatch: DispatchFn}
 ) => Promise<void>
 
-type DispatchFn =
-	| ((type: string, data?: any, ts?: number) => Promise<ESEvent>)
-	| ((arg: {type: string; data?: any; ts?: number}) => Promise<ESEvent>)
+type  DispatchFn = (...args: [type: string, data?: any, ts?: number] | [arg: { type: string; data?: any; ts?: number} ]) => Promise<ESEvent>
+
 type AddEventFn =
 	| ((type: string, data?: any) => void)
 	| ((arg: {type: string; data?: any}) => void)


### PR DESCRIPTION
Fix DispatchFn type so that TS correctly understands it as a OR between the two possible options. The way it was previously defined as an OR between two different function types effectively resulted in a logical AND on the param types because TS assumes the provided params need to satisfy BOTH the function types instead of just one. 