### PR TITLE
eSDB: add dispatch event after queueing main event

### DIFF
--- a/src/EventSourcingDB/EventSourcingDB.js
+++ b/src/EventSourcingDB/EventSourcingDB.js
@@ -465,6 +465,7 @@ class EventSourcingDB extends EventEmitter {
 	 */
 	dispatch = makeDispatcher('dispatch', async (type, data, ts) => {
 		const event = await this.queue.add(type, data, ts)
+		this.emit('dispatch', event)
 		return this.handledVersion(event.v)
 	})
 


### PR DESCRIPTION
@wmertens could you release it together with changes on tmpRelease branch?
emitting event is needed for recent updates to agent, while the rest is for OPP stuff that is already in production